### PR TITLE
feat: proxy can capture request body and headers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ Usage:
   imposter proxy [URL] [flags]
 
 Flags:
+      --capture-request-body        Capture the request body
+      --capture-request-headers     Capture the request headers
       --flat                        Flatten the response file structure
   -h, --help                        help for proxy
   -i, --ignore-duplicate-requests   Ignore duplicate requests with same method and URI (default true)

--- a/impostermodel/model.go
+++ b/impostermodel/model.go
@@ -25,11 +25,18 @@ type ResponseConfig struct {
 	Headers     *map[string]string `json:"headers,omitempty"`
 }
 
+type RequestBody struct {
+	Operator string `json:"operator"`
+	Value    string `json:"value"`
+}
+
 type Resource struct {
-	Path        string             `json:"path"`
-	Method      string             `json:"method"`
-	QueryParams *map[string]string `json:"queryParams,omitempty"`
-	Response    *ResponseConfig    `json:"response,omitempty"`
+	Path           string             `json:"path"`
+	Method         string             `json:"method"`
+	QueryParams    *map[string]string `json:"queryParams,omitempty"`
+	RequestBody    *RequestBody       `json:"requestBody,omitempty"`
+	RequestHeaders *map[string]string `json:"requestHeaders,omitempty"`
+	Response       *ResponseConfig    `json:"response,omitempty"`
 }
 
 type PluginConfig struct {

--- a/proxy/content.go
+++ b/proxy/content.go
@@ -1,0 +1,36 @@
+package proxy
+
+import (
+	"mime"
+	"regexp"
+)
+
+// textMediaTypes are the media types that are eligible for
+// request capture and response rewriting.
+var textMediaTypes = []string{
+	"text/.+",
+	"application/javascript",
+	"application/json",
+	"application/xml",
+	"application/x-www-form-urlencoded",
+}
+
+// isTextContentType returns true if the media type is eligible for
+// request capture and response rewriting.
+func isTextContentType(contentType string) bool {
+	if contentType == "" {
+		logger.Warnf("missing content type")
+		return false
+	}
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		logger.Warnf("failed to parse content type: %v: %v", contentType, err)
+		return false
+	}
+	for _, rewriteMediaType := range textMediaTypes {
+		if matched, _ := regexp.MatchString(rewriteMediaType, mediaType); matched {
+			return true
+		}
+	}
+	return false
+}

--- a/proxy/content_test.go
+++ b/proxy/content_test.go
@@ -1,0 +1,62 @@
+package proxy
+
+import "testing"
+
+func Test_isTextContentType(t *testing.T) {
+	type args struct {
+		contentType string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "empty content type",
+			args: args{contentType: ""},
+			want: false,
+		},
+		{
+			name: "invalid content type",
+			args: args{contentType: "invalid/contenttype"},
+			want: false,
+		},
+		{
+			name: "text content type",
+			args: args{contentType: "text/plain"},
+			want: true,
+		},
+		{
+			name: "json content type",
+			args: args{contentType: "application/json"},
+			want: true,
+		},
+		{
+			name: "xml content type",
+			args: args{contentType: "application/xml"},
+			want: true,
+		},
+		{
+			name: "javascript content type",
+			args: args{contentType: "application/javascript"},
+			want: true,
+		},
+		{
+			name: "form-urlencoded content type",
+			args: args{contentType: "application/x-www-form-urlencoded"},
+			want: true,
+		},
+		{
+			name: "non-text content type",
+			args: args{contentType: "application/octet-stream"},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isTextContentType(tt.args.contentType); got != tt.want {
+				t.Errorf("isTextContentType() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -30,6 +30,7 @@ import (
 
 type HttpExchange struct {
 	Request         *http.Request
+	RequestBody     *[]byte
 	StatusCode      int
 	ResponseBody    *[]byte
 	ResponseHeaders *http.Header
@@ -80,7 +81,7 @@ func Handle(
 	upstream string,
 	w http.ResponseWriter,
 	req *http.Request,
-	listener func(statusCode int, respBody *[]byte, respHeaders *http.Header) (*[]byte, *http.Header),
+	listener func(reqBody *[]byte, statusCode int, respBody *[]byte, respHeaders *http.Header) (*[]byte, *http.Header),
 ) {
 	startTime := time.Now()
 
@@ -101,7 +102,7 @@ func Handle(
 		return
 	}
 
-	responseBody, respHeaders = listener(statusCode, responseBody, respHeaders)
+	responseBody, respHeaders = listener(requestBody, statusCode, responseBody, respHeaders)
 
 	err = sendResponse(w, respHeaders, statusCode, responseBody, client)
 	if err != nil {

--- a/proxy/recorder_test.go
+++ b/proxy/recorder_test.go
@@ -2,10 +2,12 @@ package proxy
 
 import (
 	"fmt"
+	"gatehill.io/imposter/impostermodel"
 	"net/http"
 	"net/url"
 	"os"
 	"path"
+	"reflect"
 	"testing"
 )
 
@@ -90,6 +92,201 @@ func Test_getResponseFile(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Errorf("getResponseFile() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_buildResource(t *testing.T) {
+	outputDir, err := os.MkdirTemp(os.TempDir(), "imposter-cli")
+	if err != nil {
+		panic(err)
+	}
+	rootUrl, _ := url.Parse("https://example.com/")
+
+	type args struct {
+		dir      string
+		options  RecorderOptions
+		exchange HttpExchange
+		respFile string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    impostermodel.Resource
+		wantErr bool
+	}{
+		{
+			name: "request with query params",
+			args: args{
+				dir: outputDir,
+				options: RecorderOptions{
+					CaptureRequestBody:    false,
+					CaptureRequestHeaders: false,
+				},
+				exchange: HttpExchange{
+					Request: &http.Request{
+						Method: "GET",
+						URL:    &url.URL{Path: "/test", RawQuery: "param1=value1&param2=value2"},
+					},
+					ResponseHeaders: &http.Header{},
+				},
+				respFile: "",
+			},
+			want: impostermodel.Resource{
+				Path:   "/test",
+				Method: "GET",
+				QueryParams: &map[string]string{
+					"param1": "value1",
+					"param2": "value2",
+				},
+				Response: &impostermodel.ResponseConfig{
+					StatusCode: 0,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "request with headers",
+			args: args{
+				dir: outputDir,
+				options: RecorderOptions{
+					CaptureRequestBody:    false,
+					CaptureRequestHeaders: true,
+				},
+				exchange: HttpExchange{
+					Request: &http.Request{
+						Method: "GET",
+						URL:    rootUrl,
+						Header: http.Header{
+							"Header1": []string{"value1"},
+							"Header2": []string{"value2"},
+						},
+					},
+					ResponseHeaders: &http.Header{},
+				},
+				respFile: "",
+			},
+			want: impostermodel.Resource{
+				Path:   "/",
+				Method: "GET",
+				RequestHeaders: &map[string]string{
+					"Header1": "value1",
+					"Header2": "value2",
+				},
+				Response: &impostermodel.ResponseConfig{
+					StatusCode: 0,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "request with body",
+			args: args{
+				dir: outputDir,
+				options: RecorderOptions{
+					CaptureRequestBody:    true,
+					CaptureRequestHeaders: false,
+				},
+				exchange: HttpExchange{
+					Request: &http.Request{
+						Method: "POST",
+						URL:    rootUrl,
+						Header: http.Header{
+							"Content-Type": []string{"application/json"},
+						},
+					},
+					RequestBody: func() *[]byte {
+						body := []byte(`{"key":"value"}`)
+						return &body
+					}(),
+					ResponseHeaders: &http.Header{},
+				},
+				respFile: "",
+			},
+			want: impostermodel.Resource{
+				Path:   "/",
+				Method: "POST",
+				RequestBody: &impostermodel.RequestBody{
+					Value:    `{"key":"value"}`,
+					Operator: "EqualTo",
+				},
+				Response: &impostermodel.ResponseConfig{
+					StatusCode: 0,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "request with unsupported content type",
+			args: args{
+				dir: outputDir,
+				options: RecorderOptions{
+					CaptureRequestBody:    true,
+					CaptureRequestHeaders: false,
+				},
+				exchange: HttpExchange{
+					Request: &http.Request{
+						Method: "POST",
+						URL:    rootUrl,
+						Header: http.Header{
+							"Content-Type": []string{"application/octet-stream"},
+						},
+					},
+					RequestBody: func() *[]byte {
+						body := []byte(`{"key":"value"}`)
+						return &body
+					}(),
+					ResponseHeaders: &http.Header{},
+				},
+				respFile: "",
+			},
+			want: impostermodel.Resource{
+				Path:   "/",
+				Method: "POST",
+				Response: &impostermodel.ResponseConfig{
+					StatusCode: 0,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "request with response file",
+			args: args{
+				dir: outputDir,
+				options: RecorderOptions{
+					CaptureRequestBody:    false,
+					CaptureRequestHeaders: false,
+				},
+				exchange: HttpExchange{
+					Request: &http.Request{
+						Method: "GET",
+						URL:    rootUrl,
+					},
+					ResponseHeaders: &http.Header{},
+				},
+				respFile: path.Join(outputDir, "response.txt"),
+			},
+			want: impostermodel.Resource{
+				Path:   "/",
+				Method: "GET",
+				Response: &impostermodel.ResponseConfig{
+					StatusCode: 0,
+					StaticFile: "response.txt",
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildResource(tt.args.dir, tt.args.options, tt.args.exchange, tt.args.respFile)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("buildResource() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("buildResource() got = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/proxy/rewrite.go
+++ b/proxy/rewrite.go
@@ -19,38 +19,13 @@ package proxy
 import (
 	"bytes"
 	"fmt"
-	"mime"
 	"net/http"
-	"regexp"
 )
-
-var rewriteMediaTypes = []string{
-	"text/.+",
-	"application/javascript",
-	"application/json",
-	"application/xml",
-}
 
 func Rewrite(respHeaders *http.Header, respBody *[]byte, upstream string, port int) *[]byte {
 	contentType := (*respHeaders).Get("Content-Type")
-	if contentType == "" {
-		logger.Warnf("no content type - skipping rewrite")
-		return respBody
-	}
-	mediaType, _, err := mime.ParseMediaType(contentType)
-	if err != nil {
-		logger.Warnf("failed to parse content type - skipping rewrite: %v", err)
-		return respBody
-	}
-	rewrite := false
-	for _, rewriteMediaType := range rewriteMediaTypes {
-		if matched, _ := regexp.MatchString(rewriteMediaType, mediaType); matched {
-			rewrite = true
-			break
-		}
-	}
-	if !rewrite {
-		logger.Debugf("unsupported content type %s for rewrite - skipping rewrite", mediaType)
+	if !isTextContentType(contentType) {
+		logger.Debugf("unsupported content type '%s' for rewrite - skipping rewrite", contentType)
 		return respBody
 	}
 	rewritten := bytes.ReplaceAll(*respBody, []byte(upstream), []byte(fmt.Sprintf("http://localhost:%d", port)))


### PR DESCRIPTION
See https://github.com/outofcoffee/imposter/issues/628

Usage:

```
imposter  proxy http://example.com --capture-request-body --capture-request-headers --output-dir=/tmp/proxy
```

Test:

```
curl http://localhost:8080/foo -H 'bar:baz' --data 'foo' -H 'content-type: text/plain' --raw -v
```

Output:

```yaml
plugin: rest
resources:
- method: POST
  path: /foo
  requestBody:
    operator: EqualTo
    value: foo
  requestHeaders:
    Accept: '*/*'
    Bar: baz
    Content-Type: text/plain
    User-Agent: curl/8.7.1
  response:
    headers:
      Content-Type: text/html; charset=UTF-8
    statusCode: 405
```