### PR TITLE
feat(proxy): add --insecure flag to skip upstream TLS verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,11 @@ Example:
 
     imposter proxy https://example.com
 
+To proxy an HTTPS upstream that uses a self-signed or otherwise untrusted
+certificate, add `--insecure` to skip TLS verification:
+
+    imposter proxy --insecure https://self-signed.example.com
+
 Usage:
 
 ```
@@ -198,6 +203,7 @@ Flags:
       --flat                        Flatten the response file structure
   -h, --help                        help for proxy
   -i, --ignore-duplicate-requests   Ignore duplicate requests with same method and URI (default true)
+      --insecure                    Skip TLS certificate verification when forwarding to the upstream
   -o, --output-dir string           Directory in which HTTP exchanges are recorded (default: current working directory)
   -p, --port int                    Port on which to listen (default 8080)
   -H, --response-headers strings    Record only these response headers

--- a/cmd/proxy.go
+++ b/cmd/proxy.go
@@ -33,6 +33,7 @@ var proxyFlags = struct {
 	ignoreDuplicateRequests   bool
 	recordOnlyResponseHeaders []string
 	flatResponseFileStructure bool
+	insecure                  bool
 }{}
 
 // proxyCmd represents the up command
@@ -60,7 +61,7 @@ var proxyCmd = &cobra.Command{
 			RecordOnlyResponseHeaders: proxyFlags.recordOnlyResponseHeaders,
 			FlatResponseFileStructure: proxyFlags.flatResponseFileStructure,
 		}
-		proxyUpstream(upstream, proxyFlags.port, outputDir, proxyFlags.rewrite, options)
+		proxyUpstream(upstream, proxyFlags.port, outputDir, proxyFlags.rewrite, proxyFlags.insecure, options)
 	},
 }
 
@@ -73,10 +74,11 @@ func init() {
 	proxyCmd.Flags().BoolVarP(&proxyFlags.ignoreDuplicateRequests, "ignore-duplicate-requests", "i", true, "Ignore duplicate requests with same method and URI")
 	proxyCmd.Flags().StringSliceVarP(&proxyFlags.recordOnlyResponseHeaders, "response-headers", "H", nil, "Record only these response headers")
 	proxyCmd.Flags().BoolVar(&proxyFlags.flatResponseFileStructure, "flat", false, "Flatten the response file structure")
+	proxyCmd.Flags().BoolVar(&proxyFlags.insecure, "insecure", false, "Skip TLS certificate verification when forwarding to the upstream")
 	rootCmd.AddCommand(proxyCmd)
 }
 
-func proxyUpstream(upstream string, port int, dir string, rewrite bool, options proxy2.RecorderOptions) {
+func proxyUpstream(upstream string, port int, dir string, rewrite bool, insecure bool, options proxy2.RecorderOptions) {
 	logger.Infof("starting proxy for upstream %s on port %v", upstream, port)
 	recorderC, err := proxy2.StartRecorder(upstream, dir, options)
 	if err != nil {
@@ -88,7 +90,7 @@ func proxyUpstream(upstream string, port int, dir string, rewrite bool, options 
 		_, _ = fmt.Fprintf(writer, "ok\n")
 	})
 	mux.HandleFunc("/", func(writer http.ResponseWriter, request *http.Request) {
-		proxy2.Handle(upstream, writer, request, func(reqBody *[]byte, statusCode int, respBody *[]byte, respHeaders *http.Header) (*[]byte, *http.Header) {
+		proxy2.Handle(upstream, writer, request, insecure, func(reqBody *[]byte, statusCode int, respBody *[]byte, respHeaders *http.Header) (*[]byte, *http.Header) {
 			if rewrite {
 				respBody = proxy2.Rewrite(respHeaders, respBody, upstream, port)
 			}

--- a/cmd/proxy_test.go
+++ b/cmd/proxy_test.go
@@ -79,7 +79,7 @@ func Test_proxyUpstream(t *testing.T) {
 			}
 
 			go func() {
-				proxyUpstream(upstream, port, outputDir, tt.args.rewrite, tt.args.options)
+				proxyUpstream(upstream, port, outputDir, tt.args.rewrite, false, tt.args.options)
 			}()
 			if up := engine.WaitUntilUp(port, nil); !up {
 				t.Fatalf("proxy did not come up on port %d", port)

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -18,6 +18,7 @@ package proxy
 
 import (
 	"bytes"
+	"crypto/tls"
 	"fmt"
 	"gatehill.io/imposter/internal/logging"
 	"gatehill.io/imposter/internal/stringutil"
@@ -25,6 +26,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sync"
 	"time"
 )
 
@@ -66,21 +68,43 @@ var skipRecordHeaders = []string{
 
 var logger = logging.GetLogger()
 
-var transport *http.Transport
+// defaultTransport returns the shared transport used for verified TLS
+// (or plain HTTP) upstream requests.
+var defaultTransport = sync.OnceValue(func() *http.Transport {
+	return newTransport(false)
+})
 
-func init() {
-	transport = &http.Transport{
+// insecureTransport returns the shared transport used for requests where
+// TLS certificate verification has been explicitly disabled.
+var insecureTransport = sync.OnceValue(func() *http.Transport {
+	return newTransport(true)
+})
+
+func newTransport(insecure bool) *http.Transport {
+	t := &http.Transport{
 		DisableCompression: true,
 		MaxIdleConns:       viper.GetInt("proxy.maxIdleConns"),
 		IdleConnTimeout:    viper.GetDuration("proxy.idleConnTimeout"),
 	}
-	logger.Tracef("initialised proxy transport: %+v", transport)
+	if insecure {
+		t.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	}
+	logger.Tracef("initialised proxy transport (insecure=%v): %+v", insecure, t)
+	return t
+}
+
+func getTransport(insecure bool) *http.Transport {
+	if insecure {
+		return insecureTransport()
+	}
+	return defaultTransport()
 }
 
 func Handle(
 	upstream string,
 	w http.ResponseWriter,
 	req *http.Request,
+	insecure bool,
 	listener func(reqBody *[]byte, statusCode int, respBody *[]byte, respHeaders *http.Header) (*[]byte, *http.Header),
 ) {
 	startTime := time.Now()
@@ -95,7 +119,7 @@ func Handle(
 		return
 	}
 
-	statusCode, responseBody, respHeaders, err := forward(upstream, req.Method, path, queryString, clientReqHeaders, requestBody)
+	statusCode, responseBody, respHeaders, err := forward(upstream, req.Method, path, queryString, clientReqHeaders, requestBody, insecure)
 	if err != nil {
 		logger.Error(err)
 		w.WriteHeader(http.StatusBadGateway)
@@ -131,6 +155,7 @@ func forward(
 	queryString string,
 	clientRequestHeaders *http.Header,
 	requestBody *[]byte,
+	insecure bool,
 ) (statusCode int, responseBody *[]byte, upstreamRespHeaders *http.Header, err error) {
 	logger.Debugf("invoking upstream %s with %s %s [body: %v bytes]", upstream, httpMethod, path, len(*requestBody))
 
@@ -147,7 +172,7 @@ func forward(
 	upstreamReqHeaders := req.Header
 	copyHeaders(clientRequestHeaders, &upstreamReqHeaders)
 
-	client := &http.Client{Transport: transport}
+	client := &http.Client{Transport: getTransport(insecure)}
 	resp, err := client.Do(req)
 	if err != nil {
 		return 0, nil, nil, err

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -172,7 +172,7 @@ func TestHandle(t *testing.T) {
 			}
 
 			// Call the Handle function with our test server as upstream
-			Handle(server.URL, rr, req, listenerFn)
+			Handle(server.URL, rr, req, false, listenerFn)
 
 			// Verify status code
 			if capturedStatusCode != tc.statusCode {
@@ -213,6 +213,67 @@ func TestHandle(t *testing.T) {
 				actualValue := rr.Header().Get(headerName)
 				if actualValue != expectedValue {
 					t.Errorf("Expected response header %s=%s, got %s", headerName, expectedValue, actualValue)
+				}
+			}
+		})
+	}
+}
+
+// TestHandleInsecureTLS verifies that the insecure flag controls whether
+// requests to an upstream with a self-signed TLS certificate succeed.
+func TestHandleInsecureTLS(t *testing.T) {
+	// Upstream with a self-signed certificate (httptest.NewTLSServer).
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("secure hello"))
+	}))
+	defer upstream.Close()
+
+	cases := []struct {
+		name           string
+		insecure       bool
+		expectUpstream bool
+	}{
+		{name: "verified TLS rejects self-signed", insecure: false, expectUpstream: false},
+		{name: "insecure TLS accepts self-signed", insecure: true, expectUpstream: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := http.NewRequest("GET", "/", http.NoBody)
+			if err != nil {
+				t.Fatalf("failed to create request: %v", err)
+			}
+			req.RemoteAddr = "127.0.0.1:12345"
+
+			rr := httptest.NewRecorder()
+			var listenerCalled bool
+			listener := func(reqBody *[]byte, statusCode int, respBody *[]byte, respHeaders *http.Header) (*[]byte, *http.Header) {
+				listenerCalled = true
+				return respBody, respHeaders
+			}
+
+			Handle(upstream.URL, rr, req, tc.insecure, listener)
+
+			if tc.expectUpstream {
+				if !listenerCalled {
+					t.Fatalf("expected listener to be called when insecure=true")
+				}
+				if rr.Code != http.StatusOK {
+					t.Errorf("expected status 200, got %d", rr.Code)
+				}
+				if rr.Body.String() != "secure hello" {
+					t.Errorf("expected body %q, got %q", "secure hello", rr.Body.String())
+				}
+			} else {
+				// TLS verification should fail: Handle returns 502 BadGateway
+				// and the listener is never invoked.
+				if listenerCalled {
+					t.Errorf("expected listener NOT to be called when insecure=false against self-signed cert")
+				}
+				if rr.Code != http.StatusBadGateway {
+					t.Errorf("expected status 502, got %d", rr.Code)
 				}
 			}
 		})
@@ -268,7 +329,7 @@ func TestHandleEndToEnd(t *testing.T) {
 		w.Write([]byte(`{"status":"OK"}`))
 	})
 	proxyMux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		Handle(upstreamURL, w, r, func(reqBody *[]byte, statusCode int, respBody *[]byte, respHeaders *http.Header) (*[]byte, *http.Header) {
+		Handle(upstreamURL, w, r, false, func(reqBody *[]byte, statusCode int, respBody *[]byte, respHeaders *http.Header) (*[]byte, *http.Header) {
 			// Pass through unchanged
 			return respBody, respHeaders
 		})


### PR DESCRIPTION
## Summary
- Adds an `--insecure` flag to `imposter proxy` for upstreams that serve a self-signed or otherwise untrusted TLS certificate.
- The flag threads through `Handle` → `forward` and selects between two cached `http.Transport` instances (one verified, one with `InsecureSkipVerify`), so default behaviour is unchanged when the flag is absent.

## Motivation
Split out of the `--insecure` portion of #82 so it can be reviewed and merged independently of the SOAP-aware proxy work.
