### PR TITLE
feat(proxy): auto-detect SOAP action for request differentiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,13 @@ Reliable, scriptable and extensible mock server for REST APIs, OpenAPI (and Swag
 
 > This project is the CLI tool for the [Imposter mock engine](https://www.imposter.sh).
 
-Start a live mock of an OpenAPI specification with just:
+Stand up a live mock from an OpenAPI spec in one command:
 
 ```shell
 $ imposter up -s
 
 found 1 OpenAPI spec(s)
 starting server on port 8080...
-...
 mock server up and running at http://localhost:8080
 ```
 
@@ -19,22 +18,21 @@ You now have a live mock of your OpenAPI spec running on localhost.
 
 ---
 
-Or create a mock by proxying an exising endpoint:
+Record HTTP exchanges by proxying a real endpoint, then replay them as a mock:
 
 ```shell
 $ imposter proxy https://example.com
 
 starting proxy on port 8080
-...
 wrote response file /users.json for request GET /users
 wrote config file example.com-config.yaml
 ```
 
-Once you've recorded the HTTP exchanges, just run `imposter up` to start your mock. 
+Run `imposter up` to start the mock you just recorded.
 
 ---
 
-Or create a mock from an existing OpenAPI file:
+Or scaffold a mock straight from an OpenAPI/WSDL file:
 
 ```shell
 $ imposter scaffold
@@ -44,7 +42,7 @@ generated 1 resources from spec
 wrote Imposter config: /Users/mary/example/petstore-config.yaml
 ```
 
-Just run `imposter up` to start your mock.
+Run `imposter up` to start your mock.
 
 <img src="./docs/img/imposter-scaffold.gif" alt="Screenshot of scaffold command" width="67%">
 
@@ -52,405 +50,96 @@ Just run `imposter up` to start your mock.
 
 ## Features
 
-- run standalone mocks in place of real systems
-- turn an OpenAPI/Swagger file into a mock API for testing or QA (even before the real API is built)
-- decouple your integration tests from the cloud/various back-end systems and take control of your dependencies
-- validate your API requests against an OpenAPI specification
-- capture data and validate later or use response templates to provide conditional responses
-- proxy an existing endpoint to replay its responses as a mock
+- Stand up mocks in place of real systems, locally or in CI
+- Turn an OpenAPI/Swagger or WSDL file into a working mock — even before the real API exists
+- Decouple integration tests from cloud and back-end dependencies
+- Validate requests against an OpenAPI specification
+- Capture data and serve conditional, templated responses
+- Store data for later retrieval or validation
+- Proxy and record an existing endpoint to replay it as a mock
+- Drive responses with JavaScript, Groovy, or your own plugin
 
-Send dynamic responses:
+## Install
 
-- Provide mock responses using static files or customise behaviour based on characteristics of the request.
-- Power users can control mock responses with JavaScript or Java/Groovy script engines.
-- Advanced users can write their own plugins in a JVM language of their choice.
+You'll need [Docker](https://docs.docker.com/get-docker/), or alternatively a JVM ([JVM engine](./docs/engine_jvm.md)) or no extra runtime at all ([Golang engine](./docs/engine_golang.md)).
 
-## Getting started & documentation
+### Homebrew
 
-You must have [Docker](https://docs.docker.com/get-docker/) installed and running, or if Docker is not available, you can run on the [JVM](./docs/engine_jvm.md) or use the [Golang](./docs/engine_golang.md) engine.
+```shell
+brew tap imposter-project/imposter
+brew install imposter
+```
 
-### Installation
-
-See the [Installation](./docs/install.md) instructions for your system or follow the quick-start instructions below:
-
-#### Homebrew
-
-If you have Homebrew installed:
-
-    brew tap imposter-project/imposter
-    brew install imposter
-
-#### Shell script
-
-Or, use this one liner (macOS and Linux only):
+### Shell script (macOS and Linux)
 
 ```shell
 curl -L https://raw.githubusercontent.com/imposter-project/imposter-cli/main/install/install_imposter.sh | bash -
 ```
 
-## Usage
-
-Top level command:
-
-```
-Usage:
-  imposter [command]
-
-Available Commands:
-  up                Start live mocks of APIs
-  scaffold          Create Imposter configuration from OpenAPI specs and WSDL files
-  engine pull       Pull the engine into the cache
-  engine list       List the engines in the cache
-  doctor            Check prerequisites for running Imposter
-  down              Stop running mocks
-  list              List running mocks
-  plugin install    Install plugin
-  plugin list       List installed plugins
-  plugin uninstall  Uninstall plugins
-  proxy             Proxy an endpoint and record HTTP exchanges
-  version           Print CLI version
-  remote config     Configure remote
-  remote deploy     Deploy active workspace
-  remote show       Show remote
-  remote status     Show remote status
-  workspace delete  Delete a workspace
-  workspace list    List all workspaces
-  workspace new     Create a workspace
-  workspace select  Set the active workspace
-  help              Help about any command
-```
-
-### Create and start mocks
-
-Example:
-
-    imposter up
-
-Usage:
-
-```
-Starts a live mock of your APIs, using their Imposter configuration.
-
-If CONFIG_DIR is not specified, the current working directory is used.
-
-Usage:
-  imposter up [CONFIG_DIR] [flags]
-
-Flags:
-      --auto-restart              Automatically restart when config dir contents change (default true)
-      --debug-mode                Enable JVM debug mode and listen on port 8000
-      --deduplicate string        Override deduplication ID for replacement of containers
-      --enable-file-cache         Enable file cache (default true)
-      --enable-plugins            Enable plugins (default true)
-  -t, --engine-type string        Imposter engine type (valid: docker,jvm - default "docker")
-  -e, --env stringArray           Explicit environment variables to set
-  -h, --help                      help for up
-      --install-default-plugins   Install missing default plugins (default true)
-      --mount-dir stringArray     (Docker engine type only) Extra directory bind-mounts in the form HOST_PATH:CONTAINER_PATH (e.g. $HOME/somedir:/opt/imposter/somedir) or simply HOST_PATH, which will mount the directory at /opt/imposter/<dir>
-  -p, --port int                  Port on which to listen (default 8080)
-      --pull                      Force engine pull
-  -r, --recursive-config-scan     Scan for config files in subdirectories (default false)
-  -s, --scaffold                  Scaffold Imposter configuration for all OpenAPI and WSDL files
-  -v, --version string            Imposter engine version (default "latest")
-```
-
-### Generate Imposter configuration
-
-Example:
-
-    imposter scaffold
-
-Usage:
-
-```
-Creates Imposter configuration files. If one or more OpenAPI/Swagger
-specification files are present, they are used as the basis for the generated
-resources. If no specification files are present, a simple REST mock is created.
-
-If DIR is not specified, the current working directory is used.
-
-Usage:
-  imposter scaffold [DIR] [flags]
-
-Flags:
-  -f  --force-overwrite        Force overwrite of destination file(s) if already exist
-      --generate-resources     Generate Imposter resources from OpenAPI paths (default true)
-  -s  --script-engine string   Generate placeholder Imposter script (none|groovy|js) (default "none")
-```
-
-### Proxy HTTP(S) endpoint and record HTTP exchanges
-
-Example:
-
-    imposter proxy https://example.com
-
-To proxy an HTTPS upstream that uses a self-signed or otherwise untrusted
-certificate, add `--insecure` to skip TLS verification:
-
-    imposter proxy --insecure https://self-signed.example.com
-
-Usage:
-
-```
-Proxies an endpoint and records HTTP exchanges to file, in Imposter format.
-
-Usage:
-  imposter proxy [URL] [flags]
-
-Flags:
-      --capture-request-body        Capture the request body
-      --capture-request-headers     Capture the request headers
-      --flat                        Flatten the response file structure
-  -h, --help                        help for proxy
-  -i, --ignore-duplicate-requests   Ignore duplicate requests with same method and URI (default true)
-      --insecure                    Skip TLS certificate verification when forwarding to the upstream
-  -o, --output-dir string           Directory in which HTTP exchanges are recorded (default: current working directory)
-  -p, --port int                    Port on which to listen (default 8080)
-  -H, --response-headers strings    Record only these response headers
-  -r, --rewrite-urls                Rewrite upstream URL in response body to proxy URL
-```
-
-### Pull engine
-
-Example:
-
-    imposter engine pull
-
-Usage:
-
-```
-Pulls a specified version of the engine binary/image into the cache.
-
-If version is not specified, it defaults to 'latest'.
-
-Usage:
-  imposter engine pull [flags]
-
-Flags:
-  -t, --engine-type string    Imposter engine type (valid: docker,jvm - default "docker")
-  -h, --help                  help for pull
-  -f, --force                 Force engine pull
-  -v, --version string        Imposter engine version (default "latest")
-```
-
-### List installed engines
-
-Example:
-
-    imposter engine list
-
-Usage:
-
-```
-Lists all versions of engine binaries/images in the cache.
-
-If engine type is not specified, it defaults to all.
-
-Usage:
-  imposter engine list [flags]
-
-Flags:
-  -t, --engine-type string   Imposter engine type (valid: docker,jvm - default is all
-  -h, --help                 help for list
-```
-
-### Diagnose engine problems
-
-```
-Checks prerequisites for running Imposter, including those needed
-by the engines.
-
-Usage:
-  imposter doctor
-```
-
-### Stop all running mocks
-
-Example:
-
-    imposter down
-
-Usage:
-
-```
-Stops running Imposter mocks for the current engine type.
-
-Usage:
-  imposter down [flags]
-
-Flags:
-  -a, --all                  Stop mocks for all engine types
-  -t, --engine-type string   Imposter engine type (valid: docker,golang,jvm - default "docker")
-  -h, --help                 help for down
-```
-
-### List all running mocks
-
-Example:
-
-    imposter list
-
-Usage:
-
-```
-Lists running Imposter mocks for the current engine type
-and reports their health.
-
-Usage:
-  imposter list [flags]
-
-Aliases:
-  list, ls
-
-Flags:
-  -a, --all                  List mocks for all engine types
-  -t, --engine-type string   Imposter engine type (valid: docker,golang,jvm - default "docker")
-  -x, --exit-code-health     Set exit code based on mock health
-  -h, --help                 help for list
-  -q, --quiet                Quieten output; only print ID
-```
-
-#### Using as a healthcheck
-
-You can use the `list` command as a healthcheck for running mocks.
+For other platforms or manual installs, see [Installation](./docs/install.md).
+
+## Common commands
+
+Each command has full help via `imposter <command> --help`.
+
+| Command | What it does |
+| --- | --- |
+| `imposter up [DIR]` | Start a live mock from Imposter config in `DIR` (defaults to current directory). Add `-s` to scaffold first. |
+| `imposter scaffold [DIR]` | Generate Imposter config from any OpenAPI/Swagger or WSDL files in `DIR`. |
+| `imposter proxy URL` | Forward traffic to `URL` and record each exchange to disk as a replayable mock. Add `--insecure` to skip TLS verification. |
+| `imposter down` | Stop running mocks for the current engine type. Add `-a` to stop them all. |
+| `imposter list` | List running mocks and their health. `-qx` makes a tidy healthcheck. |
+| `imposter bundle [DIR]` | Bundle config and engine into a Docker image or Lambda zip. |
+| `imposter doctor` | Check that you have at least one engine ready to run. |
+| `imposter engine pull` / `engine list` | Manage cached engine binaries and images. |
+| `imposter plugin install` / `list` / `uninstall` | Manage engine plugins. |
+| `imposter remote ...` | Configure and deploy to a remote Imposter target. |
+| `imposter workspace ...` | Manage workspaces for remote deployments. |
+| `imposter version` | Print CLI and engine version info. |
+
+### Healthcheck
 
 ```shell
-$ imposter list --quiet --exit-code-health
+imposter list -qx
 ```
 
-This will return an exit code of `0` (success) if one or more mocks are running and healthy. If no mocks are running, or if one or more mock is unhealthy, a non-zero exit code will be returned.
-
-> **Note**
-> You can use the short versions of the arguments, so this can also be written:
-> ```shell
-> imposter list -qx
-> ```
-
-### Install plugin
-
-Example:
-
-    imposter plugin install [PLUGIN_NAME_1] [PLUGIN_NAME_N...]
-
-Usage:
-
-```
-Installs plugins for a specific engine version.
-
-If version is not specified, it defaults to 'latest'.
-
-Example 1: Install named plugin
-
-        imposter plugin install store-redis
-
-Example 2: Install all plugins in config file
-
-        imposter plugin install
-
-Usage:
-  imposter plugin install [PLUGIN_NAME_1] [PLUGIN_NAME_N...] [flags]
-
-Flags:
-  -h, --help             help for install
-  -d, --save-default     Whether to save the plugin as a default
-  -v, --version string   Imposter engine version (default "latest")
-```
-
-### List plugins
-
-Example:
-
-    imposter plugin list
-
-Usage:
-
-```
-Lists all versions of installed plugins.
-
-Usage:
-  imposter plugin list [flags]
-
-Aliases:
-  list, ls
-
-Flags:
-  -v, --version string   Only show plugins for a specific engine version (default show all versions)
-  -h, --help             help for list
-```
-
-### Uninstall plugins
-
-Example:
-
-    imposter plugin uninstall store-redis
-
-Usage:
-
-```
-Uninstalls plugins for a specific engine version.
-
-If version is not specified, it defaults to 'latest'.
-
-Example 1: Uninstall named plugin
-
-        imposter plugin uninstall store-redis
-
-Example 2: Uninstall multiple plugins
-
-        imposter plugin uninstall store-redis js-graal
-
-Example 3: Uninstall plugin and remove from defaults
-
-        imposter plugin uninstall store-redis --remove-default
-
-Usage:
-  imposter plugin uninstall [PLUGIN_NAME_1] [PLUGIN_NAME_N...] [flags]
-
-Aliases:
-  uninstall, rm, remove
-
-Flags:
-  -h, --help             help for uninstall
-  -d, --remove-default   Whether to remove the plugin from defaults
-  -v, --version string   Imposter engine version (default "latest")
-```
-
-### Help
-
-```
-Provides help for any command in the application.
-Simply type imposter help [path to command] for full details.
-
-Usage:
-  imposter help [command] [flags]
-```
+Exits `0` if at least one mock is running and healthy, non-zero otherwise.
 
 ## Logging
 
-The default log level is `debug`. You can override this by setting the `LOG_LEVEL` environment variable:
+Default log level is `debug`. Override with the `LOG_LEVEL` environment variable:
 
-    export LOG_LEVEL=info
+```shell
+export LOG_LEVEL=info
+```
 
-...or passing the `--log-level <LEVEL>` argument, for example:
+Or per invocation:
 
-    imposter up --log-level trace
+```shell
+imposter up --log-level trace
+```
 
 ## Configuration
 
-Learn more about [configuration](./docs/config.md).
+See [Configuration](./docs/config.md) for the CLI config file, environment variables, and engine-specific settings.
 
----
+Other deeper guides:
+
+- [Docker engine](./docs/engine_docker.md) — the default
+- [JVM engine](./docs/engine_jvm.md)
+- [Golang engine](./docs/engine_golang.md)
+- [Run the CLI itself in Docker](./docs/docker.md)
+- [SDK — embed Imposter in your Go app](./docs/sdk.md)
+- [Upgrade](./docs/upgrade.md)
 
 ## About Imposter
 
-[Imposter](https://www.imposter.sh) is a mock server for REST APIs, OpenAPI (and Swagger) specifications, SOAP web services (and WSDL files), Salesforce and HBase APIs.
+[Imposter](https://www.imposter.sh) is a mock server for REST APIs, OpenAPI/Swagger, SOAP/WSDL, Salesforce and HBase.
 
-📖 **[Read the user documentation here](https://docs.imposter.sh)**
+📖 **[Full user documentation](https://docs.imposter.sh)**
 
 ![Imposter logo](https://raw.githubusercontent.com/imposter-project/imposter-jvm-engine/main/docs/images/composite_logo13_cropped.png)
 
----
-
 ## Contributing
 
-Suggestions and improvements to the CLI or documentation are welcome. Please raise pull requests targeting the `main` branch.
+Suggestions and improvements to the CLI or its documentation are welcome. Please raise pull requests targeting the `main` branch.

--- a/cmd/proxy.go
+++ b/cmd/proxy.go
@@ -34,6 +34,7 @@ var proxyFlags = struct {
 	recordOnlyResponseHeaders []string
 	flatResponseFileStructure bool
 	insecure                  bool
+	soap11Mode                bool
 }{}
 
 // proxyCmd represents the up command
@@ -60,6 +61,7 @@ var proxyCmd = &cobra.Command{
 			IgnoreDuplicateRequests:   proxyFlags.ignoreDuplicateRequests,
 			RecordOnlyResponseHeaders: proxyFlags.recordOnlyResponseHeaders,
 			FlatResponseFileStructure: proxyFlags.flatResponseFileStructure,
+			Soap11Mode:                proxyFlags.soap11Mode,
 		}
 		proxyUpstream(upstream, proxyFlags.port, outputDir, proxyFlags.rewrite, proxyFlags.insecure, options)
 	},
@@ -75,6 +77,7 @@ func init() {
 	proxyCmd.Flags().StringSliceVarP(&proxyFlags.recordOnlyResponseHeaders, "response-headers", "H", nil, "Record only these response headers")
 	proxyCmd.Flags().BoolVar(&proxyFlags.flatResponseFileStructure, "flat", false, "Flatten the response file structure")
 	proxyCmd.Flags().BoolVar(&proxyFlags.insecure, "insecure", false, "Skip TLS certificate verification when forwarding to the upstream")
+	proxyCmd.Flags().BoolVar(&proxyFlags.soap11Mode, "soap1.1", false, "Enable SOAP 1.1/1.2 aware mode for capturing requests/responses with SOAPAction")
 	rootCmd.AddCommand(proxyCmd)
 }
 

--- a/cmd/proxy.go
+++ b/cmd/proxy.go
@@ -34,7 +34,6 @@ var proxyFlags = struct {
 	recordOnlyResponseHeaders []string
 	flatResponseFileStructure bool
 	insecure                  bool
-	soap11Mode                bool
 }{}
 
 // proxyCmd represents the up command
@@ -61,7 +60,6 @@ var proxyCmd = &cobra.Command{
 			IgnoreDuplicateRequests:   proxyFlags.ignoreDuplicateRequests,
 			RecordOnlyResponseHeaders: proxyFlags.recordOnlyResponseHeaders,
 			FlatResponseFileStructure: proxyFlags.flatResponseFileStructure,
-			Soap11Mode:                proxyFlags.soap11Mode,
 		}
 		proxyUpstream(upstream, proxyFlags.port, outputDir, proxyFlags.rewrite, proxyFlags.insecure, options)
 	},
@@ -77,7 +75,6 @@ func init() {
 	proxyCmd.Flags().StringSliceVarP(&proxyFlags.recordOnlyResponseHeaders, "response-headers", "H", nil, "Record only these response headers")
 	proxyCmd.Flags().BoolVar(&proxyFlags.flatResponseFileStructure, "flat", false, "Flatten the response file structure")
 	proxyCmd.Flags().BoolVar(&proxyFlags.insecure, "insecure", false, "Skip TLS certificate verification when forwarding to the upstream")
-	proxyCmd.Flags().BoolVar(&proxyFlags.soap11Mode, "soap1.1", false, "Enable SOAP 1.1/1.2 aware mode for capturing requests/responses with SOAPAction")
 	rootCmd.AddCommand(proxyCmd)
 }
 

--- a/cmd/proxy_test.go
+++ b/cmd/proxy_test.go
@@ -38,6 +38,7 @@ func init() {
 func Test_proxyUpstream(t *testing.T) {
 	type args struct {
 		rewrite bool
+		soap    bool
 		options proxy.RecorderOptions
 	}
 	tests := []struct {
@@ -66,9 +67,9 @@ func Test_proxyUpstream(t *testing.T) {
 			name: "proxy SOAP 1.1 service with SOAPAction",
 			args: args{
 				rewrite: false,
+				soap:    true,
 				options: proxy.RecorderOptions{
 					FlatResponseFileStructure: false,
-					Soap11Mode:                true,
 				},
 			},
 		},
@@ -96,7 +97,7 @@ func Test_proxyUpstream(t *testing.T) {
 				t.Fatalf("proxy did not come up on port %d", port)
 			}
 
-			if tt.args.options.Soap11Mode {
+			if tt.args.soap {
 				if err := sendSoapRequestToProxy(port); err != nil {
 					t.Fatal(err)
 				}
@@ -109,7 +110,7 @@ func Test_proxyUpstream(t *testing.T) {
 			upstreamHostAndPort := fmt.Sprintf("localhost-%d", upstreamPort)
 			cfgFileName := upstreamHostAndPort + "-config.yaml"
 			var indexFileName string
-			if tt.args.options.Soap11Mode {
+			if tt.args.soap {
 				if tt.args.options.FlatResponseFileStructure {
 					indexFileName = upstreamHostAndPort + "-POST-index_http___example_com_service_GetUser.txt"
 				} else {

--- a/cmd/proxy_test.go
+++ b/cmd/proxy_test.go
@@ -26,6 +26,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"strings"
 	"testing"
 	"time"
 )
@@ -61,6 +62,16 @@ func Test_proxyUpstream(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "proxy SOAP 1.1 service with SOAPAction",
+			args: args{
+				rewrite: false,
+				options: proxy.RecorderOptions{
+					FlatResponseFileStructure: false,
+					Soap11Mode:                true,
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		server, upstream, upstreamPort, err := startUpstream()
@@ -85,14 +96,26 @@ func Test_proxyUpstream(t *testing.T) {
 				t.Fatalf("proxy did not come up on port %d", port)
 			}
 
-			if err := sendRequestToProxy(port); err != nil {
-				t.Fatal(err)
+			if tt.args.options.Soap11Mode {
+				if err := sendSoapRequestToProxy(port); err != nil {
+					t.Fatal(err)
+				}
+			} else {
+				if err := sendRequestToProxy(port); err != nil {
+					t.Fatal(err)
+				}
 			}
 
 			upstreamHostAndPort := fmt.Sprintf("localhost-%d", upstreamPort)
 			cfgFileName := upstreamHostAndPort + "-config.yaml"
 			var indexFileName string
-			if tt.args.options.FlatResponseFileStructure {
+			if tt.args.options.Soap11Mode {
+				if tt.args.options.FlatResponseFileStructure {
+					indexFileName = upstreamHostAndPort + "-POST-index_http___example_com_service_GetUser.txt"
+				} else {
+					indexFileName = "POST-index_http___example_com_service_GetUser.txt"
+				}
+			} else if tt.args.options.FlatResponseFileStructure {
 				indexFileName = upstreamHostAndPort + "-GET-index.txt"
 			} else {
 				indexFileName = "GET-index.txt"
@@ -152,6 +175,43 @@ func sendRequestToProxy(port int) error {
 	_ = resp.Body.Close()
 	if resp.StatusCode == 200 {
 		logger.Tracef("proxy up at %s", url)
+		return nil
+	}
+	return nil
+}
+
+func sendSoapRequestToProxy(port int) error {
+	client := http.Client{
+		Timeout: 2 * time.Second,
+	}
+	url := fmt.Sprintf("http://localhost:%d", port)
+
+	soapBody := `<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body>
+    <GetUser xmlns="http://example.com/service">
+      <userId>123</userId>
+    </GetUser>
+  </soap:Body>
+</soap:Envelope>`
+
+	req, err := http.NewRequest("POST", url, strings.NewReader(soapBody))
+	if err != nil {
+		return fmt.Errorf("failed to create SOAP request: %s", err)
+	}
+	req.Header.Set("Content-Type", "text/xml; charset=utf-8")
+	req.Header.Set("SOAPAction", "http://example.com/service/GetUser")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("SOAP request failed for proxy at %s: %s", url, err)
+	}
+	if _, err := io.ReadAll(resp.Body); err != nil {
+		return fmt.Errorf("body read failed for proxy at %s: %s", url, err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode == 200 {
+		logger.Tracef("SOAP proxy up at %s", url)
 		return nil
 	}
 	return nil

--- a/cmd/proxy_test.go
+++ b/cmd/proxy_test.go
@@ -211,9 +211,9 @@ func sendSoapRequestToProxy(port int) error {
 		return fmt.Errorf("body read failed for proxy at %s: %s", url, err)
 	}
 	_ = resp.Body.Close()
-	if resp.StatusCode == 200 {
-		logger.Tracef("SOAP proxy up at %s", url)
-		return nil
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("SOAP proxy at %s returned status %d, want 200", url, resp.StatusCode)
 	}
+	logger.Tracef("SOAP proxy up at %s", url)
 	return nil
 }

--- a/docs/config.md
+++ b/docs/config.md
@@ -6,31 +6,9 @@ You can configure the Imposter CLI using command line arguments/flags or configu
 
 Each command has its own list of arguments and flags, accessible using the `-h` flag, such as:
 
-```
-$ imposter up -h
-Starts a live mock of your APIs, using their Imposter configuration.
+    imposter up -h
 
-If CONFIG_DIR is not specified, the current working directory is used.
-
-Usage:
-  imposter up [CONFIG_DIR] [flags]
-
-Flags:
-      --auto-restart              Automatically restart when config dir contents change (default true)
-      --deduplicate string        Override deduplication ID for replacement of containers
-      --enable-file-cache         Enable file cache (default true)
-      --enable-plugins            Enable plugins (default true)
-  -t, --engine-type string        Imposter engine type (valid: docker,jvm - default "docker")
-  -e, --env stringArray           Explicit environment variables to set
-  -h, --help                      help for up
-      --install-default-plugins   Install missing default plugins (default true)
-      --mount-dir stringArray     (Docker engine type only) Extra directory bind-mounts in the form HOST_PATH:CONTAINER_PATH (e.g. $HOME/somedir:/opt/imposter/somedir) or simply HOST_PATH, which will mount the directory at /opt/imposter/<dir>
-  -p, --port int                  Port on which to listen (default 8080)
-      --pull                      Force engine pull
-  -r, --recursive-config-scan     Scan for config files in subdirectories (default false)
-  -s, --scaffold                  Scaffold Imposter configuration for all OpenAPI and WSDL files
-  -v, --version string            Imposter engine version (default "latest")
-```
+This prints the full set of flags, defaults, and usage for the command. The same applies to every subcommand (`imposter proxy -h`, `imposter scaffold -h`, and so on).
 
 ## Mock configuration files
 
@@ -55,7 +33,7 @@ You can also use a configuration file to set CLI defaults. By default, Imposter 
 The currently supported elements are as follows:
 
 ```yaml
-# the engine type - valid values are "docker" or "jvm"
+# the engine type - valid values are "docker", "jvm" or "golang"
 engine: "docker"
 
 # the engine version - valid values are "latest", or a binary release such as "2.0.1"

--- a/docs/install.md
+++ b/docs/install.md
@@ -46,7 +46,7 @@ Only ARM64 and Intel x86_64 are supported on macOS.
 
 ```shell
 # see https://github.com/imposter-project/imposter-cli/releases
-export IMPOSTER_CLI_VERSION=0.1.0
+export IMPOSTER_CLI_VERSION=1.5.5
 
 # choose one
 export IMPOSTER_ARCH=arm64
@@ -63,7 +63,7 @@ Intel x86_64, ARM32 and ARM64 are supported on Linux.
 
 ```shell
 # see https://github.com/imposter-project/imposter-cli/releases
-export IMPOSTER_CLI_VERSION=0.1.0
+export IMPOSTER_CLI_VERSION=1.5.5
 
 # choose one
 #export IMPOSTER_ARCH=arm64
@@ -83,7 +83,7 @@ Only Intel x86_64 is supported on Windows.
 
 ```
 # see https://github.com/imposter-project/imposter-cli/releases
-SET IMPOSTER_CLI_VERSION=0.1.0
+SET IMPOSTER_CLI_VERSION=1.5.5
 
 curl.exe --output imposter-cli.zip --url "https://github.com/imposter-project/imposter-cli/releases/download/v%IMPOSTER_CLI_VERSION%/imposter-cli_windows_amd64.zip"
 unzip.exe imposter-cli.zip

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -42,18 +42,19 @@ import (
 func main() {
     configDir := "/path/to/imposter/config"
 
-    // can be docker, jvm or golang
-    engineType := docker.EnableEngine()
+    // register the engine implementation you want to use.
+    // swap for jvm.EnableEngine() or golang.EnableEngine() as required.
+    docker.EnableEngine()
 
     startOptions := engine.StartOptions{
         Port:           8080,
-        Version:        "2.4.2",
+        Version:        "latest",
         PullPolicy:     engine.PullIfNotPresent,
         LogLevel:       "DEBUG",
         ReplaceRunning: true,
     }
 
-    mockEngine := engine.BuildEngine(engineType, configDir, startOptions)
+    mockEngine := engine.BuildEngine(engine.EngineTypeDockerCore, configDir, startOptions)
 
     // block until the engine is terminated
     wg := &sync.WaitGroup{}
@@ -61,6 +62,12 @@ func main() {
     wg.Wait()
 }
 ```
+
+The matching engine type constants live on the `engine` package:
+
+- `engine.EngineTypeDockerCore` (paired with `docker.EnableEngine()`)
+- `engine.EngineTypeJvmSingleJar` (paired with `jvm.EnableEngine()`)
+- `engine.EngineTypeGolang` (paired with `golang.EnableEngine()`)
 
 ## Learn more
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -10,7 +10,7 @@ If you installed Imposter using Homebrew, upgrade as follows:
 
 ### Shell script
 
-If you used the shell script approach (macOS and Linux only), you can re-run the script to upgrade
+If you used the shell script approach (macOS and Linux only), you can re-run the script to upgrade:
 
 ```shell
 curl -L https://raw.githubusercontent.com/imposter-project/imposter-cli/main/install/install_imposter.sh | bash -
@@ -25,32 +25,36 @@ See [Releases](https://github.com/imposter-project/imposter-cli/releases) for th
 
 ### macOS
 
-Only Intel x86_64 and ARM64 are supported on macOS.
+Only ARM64 and Intel x86_64 are supported on macOS.
 
 ```shell
 # see https://github.com/imposter-project/imposter-cli/releases
-export IMPOSTER_CLI_VERSION=0.1.0
+export IMPOSTER_CLI_VERSION=1.5.5
 
-curl -L -o imposter.tar.gz "https://github.com/imposter-project/imposter-cli/releases/download/v${IMPOSTER_CLI_VERSION}/imposter_${IMPOSTER_CLI_VERSION}_macOS_x86_64.tar.gz"
-tar xvf imposter.tar.gz
+# choose one
+export IMPOSTER_ARCH=arm64
+#export IMPOSTER_ARCH=amd64
+
+curl -L -o imposter-cli.tar.gz "https://github.com/imposter-project/imposter-cli/releases/download/v${IMPOSTER_CLI_VERSION}/imposter-cli_darwin_${IMPOSTER_ARCH}.tar.gz"
+tar xvf imposter-cli.tar.gz
 mv ./imposter /usr/local/bin/imposter
 ```
 
 ### Linux
 
-Intel x86_64, ARM32 and ARM64 is supported on Linux.
+Intel x86_64, ARM32 and ARM64 are supported on Linux.
 
 ```shell
 # see https://github.com/imposter-project/imposter-cli/releases
-export IMPOSTER_CLI_VERSION=0.1.0
+export IMPOSTER_CLI_VERSION=1.5.5
 
 # choose one
 #export IMPOSTER_ARCH=arm64
 #export IMPOSTER_ARCH=arm
-export IMPOSTER_ARCH=x86_64
+export IMPOSTER_ARCH=amd64
 
-curl -L -o imposter.tar.gz "https://github.com/imposter-project/imposter-cli/releases/download/v${IMPOSTER_CLI_VERSION}/imposter_${IMPOSTER_CLI_VERSION}_Linux_{IMPOSTER_ARCH}.tar.gz"
-tar xvf imposter.tar.gz
+curl -L -o imposter-cli.tar.gz "https://github.com/imposter-project/imposter-cli/releases/download/v${IMPOSTER_CLI_VERSION}/imposter-cli_linux_${IMPOSTER_ARCH}.tar.gz"
+tar xvf imposter-cli.tar.gz
 mv ./imposter /usr/local/bin/imposter
 ```
 
@@ -62,10 +66,10 @@ Only Intel x86_64 is supported on Windows.
 
 ```
 # see https://github.com/imposter-project/imposter-cli/releases
-SET IMPOSTER_CLI_VERSION=0.1.0
+SET IMPOSTER_CLI_VERSION=1.5.5
 
-curl.exe --output imposter.zip --url "https://github.com/imposter-project/imposter-cli/releases/download/v%IMPOSTER_CLI_VERSION%/imposter_%IMPOSTER_CLI_VERSION%_Windows_x86_64.zip"
-unzip.exe imposter.zip
+curl.exe --output imposter-cli.zip --url "https://github.com/imposter-project/imposter-cli/releases/download/v%IMPOSTER_CLI_VERSION%/imposter-cli_windows_amd64.zip"
+unzip.exe imposter-cli.zip
 
 # use command (or add to PATH)
 imposter.exe [command/args]

--- a/internal/proxy/content.go
+++ b/internal/proxy/content.go
@@ -12,6 +12,7 @@ var textMediaTypes = []string{
 	"application/javascript",
 	"application/json",
 	"application/xml",
+	"application/soap\\+xml",
 	"application/x-www-form-urlencoded",
 }
 

--- a/internal/proxy/files.go
+++ b/internal/proxy/files.go
@@ -82,18 +82,11 @@ func generateRespFileName(
 		}
 		parentDir = dir
 		respFileName = upstreamHost + "-" + req.Method + "-" + flatParent + baseFileName
-		if options.Soap11Mode {
-			logger.Debugf("SOAP 1.1 mode enabled - checking for SOAPAction header")
-			if soapAction := extractSoapAction(req); soapAction != "" {
-				logger.Debugf("Found SOAPAction: '%s', generating SOAP-aware filename", soapAction)
-				sanitizedAction := strings.ReplaceAll(soapAction, "/", "_")
-				sanitizedAction = strings.ReplaceAll(sanitizedAction, ":", "_")
-				sanitizedAction = strings.ReplaceAll(sanitizedAction, ".", "_")
-				respFileName = respFileName + "_" + sanitizedAction
-				logger.Debugf("Generated SOAP filename: '%s'", respFileName)
-			} else {
-				logger.Debugf("No SOAPAction found, using standard filename")
-			}
+		if soapAction := extractSoapAction(req); soapAction != "" {
+			sanitizedAction := strings.ReplaceAll(soapAction, "/", "_")
+			sanitizedAction = strings.ReplaceAll(sanitizedAction, ":", "_")
+			sanitizedAction = strings.ReplaceAll(sanitizedAction, ".", "_")
+			respFileName = respFileName + "_" + sanitizedAction
 		}
 
 	} else {
@@ -102,13 +95,11 @@ func generateRespFileName(
 			return "", err
 		}
 		respFileName = req.Method + "-" + baseFileName
-		if options.Soap11Mode {
-			if soapAction := extractSoapAction(req); soapAction != "" {
-				sanitizedAction := strings.ReplaceAll(soapAction, "/", "_")
-				sanitizedAction = strings.ReplaceAll(sanitizedAction, ":", "_")
-				sanitizedAction = strings.ReplaceAll(sanitizedAction, ".", "_")
-				respFileName = respFileName + "_" + sanitizedAction
-			}
+		if soapAction := extractSoapAction(req); soapAction != "" {
+			sanitizedAction := strings.ReplaceAll(soapAction, "/", "_")
+			sanitizedAction = strings.ReplaceAll(sanitizedAction, ":", "_")
+			sanitizedAction = strings.ReplaceAll(sanitizedAction, ".", "_")
+			respFileName = respFileName + "_" + sanitizedAction
 		}
 	}
 

--- a/internal/proxy/files.go
+++ b/internal/proxy/files.go
@@ -27,46 +27,31 @@ import (
 	"strings"
 )
 
-// extractSoapAction extracts the SOAPAction header from the request or
-// Content-Type action parameter (for SOAP 1.2).
+// extractSoapAction returns the SOAP action for the request, looking first
+// at the SOAPAction header (SOAP 1.1) and falling back to the `action`
+// parameter on the Content-Type header (SOAP 1.2). The value is unquoted.
+// An empty string is returned when no action is present.
 func extractSoapAction(req *http.Request) string {
-	// First try the SOAPAction header (SOAP 1.1)
-	soapAction := req.Header.Get("SOAPAction")
-	logger.Debugf("SOAPAction header raw value: '%s'", soapAction)
-
-	if soapAction == "" {
-		// Try Content-Type action parameter (SOAP 1.2)
-		contentType := req.Header.Get("Content-Type")
-		logger.Debugf("Content-Type header: '%s'", contentType)
-
-		if strings.Contains(contentType, "action=") {
-			parts := strings.Split(contentType, "action=")
-			if len(parts) > 1 {
-				actionPart := strings.TrimSpace(parts[1])
-				if strings.HasPrefix(actionPart, "\"") {
-					if endQuote := strings.Index(actionPart[1:], "\""); endQuote != -1 {
-						soapAction = actionPart[1 : endQuote+1]
-					}
-				} else {
-					if semicolon := strings.Index(actionPart, ";"); semicolon != -1 {
-						soapAction = actionPart[:semicolon]
-					} else {
-						soapAction = actionPart
-					}
-				}
-				logger.Debugf("Extracted action from Content-Type: '%s'", soapAction)
-			}
-		}
+	// SOAP 1.1: SOAPAction header
+	if soapAction := strings.Trim(req.Header.Get("SOAPAction"), "\""); soapAction != "" {
+		logger.Debugf("extracted SOAPAction from header: %q", soapAction)
+		return soapAction
 	}
-
-	if soapAction == "" {
-		logger.Debugf("No SOAPAction header or Content-Type action found in request")
+	// SOAP 1.2: action parameter on the Content-Type header
+	contentType := req.Header.Get("Content-Type")
+	if contentType == "" {
 		return ""
 	}
-
-	soapAction = strings.Trim(soapAction, "\"")
-	logger.Debugf("SOAPAction after processing: '%s'", soapAction)
-	return soapAction
+	_, params, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		logger.Debugf("failed to parse Content-Type %q: %v", contentType, err)
+		return ""
+	}
+	if action := params["action"]; action != "" {
+		logger.Debugf("extracted SOAPAction from Content-Type: %q", action)
+		return action
+	}
+	return ""
 }
 
 // generateRespFileName returns a unique filename for the given response

--- a/internal/proxy/files.go
+++ b/internal/proxy/files.go
@@ -27,6 +27,48 @@ import (
 	"strings"
 )
 
+// extractSoapAction extracts the SOAPAction header from the request or
+// Content-Type action parameter (for SOAP 1.2).
+func extractSoapAction(req *http.Request) string {
+	// First try the SOAPAction header (SOAP 1.1)
+	soapAction := req.Header.Get("SOAPAction")
+	logger.Debugf("SOAPAction header raw value: '%s'", soapAction)
+
+	if soapAction == "" {
+		// Try Content-Type action parameter (SOAP 1.2)
+		contentType := req.Header.Get("Content-Type")
+		logger.Debugf("Content-Type header: '%s'", contentType)
+
+		if strings.Contains(contentType, "action=") {
+			parts := strings.Split(contentType, "action=")
+			if len(parts) > 1 {
+				actionPart := strings.TrimSpace(parts[1])
+				if strings.HasPrefix(actionPart, "\"") {
+					if endQuote := strings.Index(actionPart[1:], "\""); endQuote != -1 {
+						soapAction = actionPart[1 : endQuote+1]
+					}
+				} else {
+					if semicolon := strings.Index(actionPart, ";"); semicolon != -1 {
+						soapAction = actionPart[:semicolon]
+					} else {
+						soapAction = actionPart
+					}
+				}
+				logger.Debugf("Extracted action from Content-Type: '%s'", soapAction)
+			}
+		}
+	}
+
+	if soapAction == "" {
+		logger.Debugf("No SOAPAction header or Content-Type action found in request")
+		return ""
+	}
+
+	soapAction = strings.Trim(soapAction, "\"")
+	logger.Debugf("SOAPAction after processing: '%s'", soapAction)
+	return soapAction
+}
+
 // generateRespFileName returns a unique filename for the given response
 func generateRespFileName(
 	upstreamHost string,
@@ -55,6 +97,19 @@ func generateRespFileName(
 		}
 		parentDir = dir
 		respFileName = upstreamHost + "-" + req.Method + "-" + flatParent + baseFileName
+		if options.Soap11Mode {
+			logger.Debugf("SOAP 1.1 mode enabled - checking for SOAPAction header")
+			if soapAction := extractSoapAction(req); soapAction != "" {
+				logger.Debugf("Found SOAPAction: '%s', generating SOAP-aware filename", soapAction)
+				sanitizedAction := strings.ReplaceAll(soapAction, "/", "_")
+				sanitizedAction = strings.ReplaceAll(sanitizedAction, ":", "_")
+				sanitizedAction = strings.ReplaceAll(sanitizedAction, ".", "_")
+				respFileName = respFileName + "_" + sanitizedAction
+				logger.Debugf("Generated SOAP filename: '%s'", respFileName)
+			} else {
+				logger.Debugf("No SOAPAction found, using standard filename")
+			}
+		}
 
 	} else {
 		parentDir = path.Join(dir, sanitisedParent)
@@ -62,6 +117,14 @@ func generateRespFileName(
 			return "", err
 		}
 		respFileName = req.Method + "-" + baseFileName
+		if options.Soap11Mode {
+			if soapAction := extractSoapAction(req); soapAction != "" {
+				sanitizedAction := strings.ReplaceAll(soapAction, "/", "_")
+				sanitizedAction = strings.ReplaceAll(sanitizedAction, ":", "_")
+				sanitizedAction = strings.ReplaceAll(sanitizedAction, ".", "_")
+				respFileName = respFileName + "_" + sanitizedAction
+			}
+		}
 	}
 
 	var suffix string

--- a/internal/proxy/files.go
+++ b/internal/proxy/files.go
@@ -54,6 +54,12 @@ func extractSoapAction(req *http.Request) string {
 	return ""
 }
 
+// sanitiseSoapAction replaces characters that are unsafe in filenames.
+func sanitiseSoapAction(action string) string {
+	r := strings.NewReplacer("/", "_", ":", "_", ".", "_")
+	return r.Replace(action)
+}
+
 // generateRespFileName returns a unique filename for the given response
 func generateRespFileName(
 	upstreamHost string,
@@ -82,12 +88,6 @@ func generateRespFileName(
 		}
 		parentDir = dir
 		respFileName = upstreamHost + "-" + req.Method + "-" + flatParent + baseFileName
-		if soapAction := extractSoapAction(req); soapAction != "" {
-			sanitizedAction := strings.ReplaceAll(soapAction, "/", "_")
-			sanitizedAction = strings.ReplaceAll(sanitizedAction, ":", "_")
-			sanitizedAction = strings.ReplaceAll(sanitizedAction, ".", "_")
-			respFileName = respFileName + "_" + sanitizedAction
-		}
 
 	} else {
 		parentDir = path.Join(dir, sanitisedParent)
@@ -95,12 +95,9 @@ func generateRespFileName(
 			return "", err
 		}
 		respFileName = req.Method + "-" + baseFileName
-		if soapAction := extractSoapAction(req); soapAction != "" {
-			sanitizedAction := strings.ReplaceAll(soapAction, "/", "_")
-			sanitizedAction = strings.ReplaceAll(sanitizedAction, ":", "_")
-			sanitizedAction = strings.ReplaceAll(sanitizedAction, ".", "_")
-			respFileName = respFileName + "_" + sanitizedAction
-		}
+	}
+	if soapAction := extractSoapAction(req); soapAction != "" {
+		respFileName = respFileName + "_" + sanitiseSoapAction(soapAction)
 	}
 
 	var suffix string

--- a/internal/proxy/files_test.go
+++ b/internal/proxy/files_test.go
@@ -153,3 +153,98 @@ func Test_generateRespFileName(t *testing.T) {
 		})
 	}
 }
+
+func TestExtractSoapAction(t *testing.T) {
+	tests := []struct {
+		name     string
+		headers  map[string]string
+		expected string
+	}{
+		{
+			name:     "no soap headers",
+			headers:  map[string]string{},
+			expected: "",
+		},
+		{
+			name: "SOAP 1.1 quoted SOAPAction header",
+			headers: map[string]string{
+				"SOAPAction":   `"http://example.com/GetUser"`,
+				"Content-Type": "text/xml; charset=utf-8",
+			},
+			expected: "http://example.com/GetUser",
+		},
+		{
+			name: "SOAP 1.1 unquoted SOAPAction header",
+			headers: map[string]string{
+				"SOAPAction":   "http://example.com/GetUser",
+				"Content-Type": "text/xml; charset=utf-8",
+			},
+			expected: "http://example.com/GetUser",
+		},
+		{
+			name: "SOAP 1.2 action parameter, quoted",
+			headers: map[string]string{
+				"Content-Type": `application/soap+xml;charset=UTF-8;action="http://example.com/GetUser"`,
+			},
+			expected: "http://example.com/GetUser",
+		},
+		{
+			// RFC 3902 requires the SOAP 1.2 action parameter to be a
+			// quoted string. An unquoted URL contains characters that
+			// are not valid MIME token chars, so mime.ParseMediaType
+			// correctly rejects the whole header.
+			name: "SOAP 1.2 action parameter, unquoted, is rejected",
+			headers: map[string]string{
+				"Content-Type": "application/soap+xml;charset=UTF-8;action=http://example.com/GetUser",
+			},
+			expected: "",
+		},
+		{
+			name: "SOAP 1.1 header takes precedence over Content-Type action",
+			headers: map[string]string{
+				"SOAPAction":   `"http://example.com/GetUser"`,
+				"Content-Type": `application/soap+xml;action="http://example.com/Ignored"`,
+			},
+			expected: "http://example.com/GetUser",
+		},
+		{
+			name: "reaction parameter is not mistaken for action",
+			headers: map[string]string{
+				// `reaction=foo` must NOT be matched as an action.
+				"Content-Type": "application/soap+xml; reaction=foo",
+			},
+			expected: "",
+		},
+		{
+			name: "empty SOAPAction header falls back to Content-Type",
+			headers: map[string]string{
+				"SOAPAction":   `""`,
+				"Content-Type": `application/soap+xml;action="http://example.com/Fallback"`,
+			},
+			expected: "http://example.com/Fallback",
+		},
+		{
+			name: "unparseable Content-Type returns empty",
+			headers: map[string]string{
+				"Content-Type": "not a valid media type",
+			},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequest("POST", "http://example.com/service", nil)
+			if err != nil {
+				t.Fatalf("failed to create request: %v", err)
+			}
+			for k, v := range tt.headers {
+				req.Header.Set(k, v)
+			}
+			got := extractSoapAction(req)
+			if got != tt.expected {
+				t.Errorf("extractSoapAction() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/proxy/recorder.go
+++ b/internal/proxy/recorder.go
@@ -37,6 +37,7 @@ type RecorderOptions struct {
 	IgnoreDuplicateRequests   bool
 	RecordOnlyResponseHeaders []string
 	FlatResponseFileStructure bool
+	Soap11Mode                bool
 }
 
 func StartRecorder(upstream string, dir string, options RecorderOptions) (chan HttpExchange, error) {
@@ -61,7 +62,14 @@ func StartRecorder(upstream string, dir string, options RecorderOptions) (chan H
 			exchange := <-recordC
 
 			var responseFilePrefix string
-			requestHash := getRequestHash(exchange.Request)
+			var requestHash string
+			if options.Soap11Mode {
+				// In SOAP mode, use SOAPAction + path for uniqueness
+				soapAction := extractSoapAction(exchange.Request)
+				requestHash = getRequestHash(exchange.Request) + "_" + soapAction
+			} else {
+				requestHash = getRequestHash(exchange.Request)
+			}
 			if stringutil.Contains(requestHashes, requestHash) {
 				if options.IgnoreDuplicateRequests {
 					logger.Debugf("skipping recording of duplicate request %s %v", exchange.Request.Method, exchange.Request.URL)
@@ -205,6 +213,21 @@ func buildResource(
 			}
 		}
 		resource.RequestHeaders = &headers
+	} else if options.Soap11Mode {
+		// In SOAP mode, capture the header that contains the action for matching
+		if soapAction := extractSoapAction(&req); soapAction != "" {
+			headers := make(map[string]string)
+			if req.Header.Get("SOAPAction") != "" {
+				// SOAP 1.1 style - use SOAPAction header
+				headers["SOAPAction"] = soapAction
+			} else {
+				// SOAP 1.2 style - use Content-Type header verbatim
+				if contentType := req.Header.Get("Content-Type"); contentType != "" {
+					headers["Content-Type"] = contentType
+				}
+			}
+			resource.RequestHeaders = &headers
+		}
 	}
 	if options.CaptureRequestBody && exchange.RequestBody != nil {
 		contentType := req.Header.Get("Content-Type")
@@ -252,4 +275,18 @@ func updateConfigFile(exchange HttpExchange, options impostermodel2.ConfigGenera
 	}
 	logger.Debugf("wrote config file %s for %s %v", configFile, req.Method, req.URL)
 	return nil
+}
+
+// generateSoapFilename generates a filename that incorporates the SOAPAction value
+func generateSoapFilename(basePath string, soapAction string, fileType string) string {
+	sanitizedPath := strings.ReplaceAll(basePath, "/", "_")
+	sanitizedPath = strings.ReplaceAll(sanitizedPath, "\\", "_")
+
+	if soapAction != "" {
+		sanitizedAction := strings.ReplaceAll(soapAction, "/", "_")
+		sanitizedAction = strings.ReplaceAll(sanitizedAction, "\\", "_")
+		sanitizedAction = strings.ReplaceAll(sanitizedAction, ":", "_")
+		return fmt.Sprintf("%s_%s.%s", sanitizedPath, sanitizedAction, fileType)
+	}
+	return fmt.Sprintf("%s.%s", sanitizedPath, fileType)
 }

--- a/internal/proxy/recorder.go
+++ b/internal/proxy/recorder.go
@@ -265,16 +265,3 @@ func updateConfigFile(exchange HttpExchange, options impostermodel2.ConfigGenera
 	return nil
 }
 
-// generateSoapFilename generates a filename that incorporates the SOAPAction value
-func generateSoapFilename(basePath string, soapAction string, fileType string) string {
-	sanitizedPath := strings.ReplaceAll(basePath, "/", "_")
-	sanitizedPath = strings.ReplaceAll(sanitizedPath, "\\", "_")
-
-	if soapAction != "" {
-		sanitizedAction := strings.ReplaceAll(soapAction, "/", "_")
-		sanitizedAction = strings.ReplaceAll(sanitizedAction, "\\", "_")
-		sanitizedAction = strings.ReplaceAll(sanitizedAction, ":", "_")
-		return fmt.Sprintf("%s_%s.%s", sanitizedPath, sanitizedAction, fileType)
-	}
-	return fmt.Sprintf("%s.%s", sanitizedPath, fileType)
-}

--- a/internal/proxy/recorder.go
+++ b/internal/proxy/recorder.go
@@ -62,9 +62,6 @@ func StartRecorder(upstream string, dir string, options RecorderOptions) (chan H
 
 			var responseFilePrefix string
 			requestHash := getRequestHash(exchange.Request)
-			if soapAction := extractSoapAction(exchange.Request); soapAction != "" {
-				requestHash = requestHash + "_" + soapAction
-			}
 			if stringutil.Contains(requestHashes, requestHash) {
 				if options.IgnoreDuplicateRequests {
 					logger.Debugf("skipping recording of duplicate request %s %v", exchange.Request.Method, exchange.Request.URL)
@@ -248,10 +245,15 @@ func buildResource(
 	return resource, nil
 }
 
-// getRequestHash generates a hash for a request based on the HTTP method and the URL. It does
-// not take into consideration request headers.
+// getRequestHash generates a hash for a request based on the HTTP method,
+// URL, and SOAP action (if present). This ensures that SOAP operations
+// sharing the same endpoint URL are treated as distinct requests.
 func getRequestHash(req *http.Request) string {
-	return stringutil.Sha1hashString(req.Method + req.URL.String())
+	key := req.Method + req.URL.String()
+	if soapAction := extractSoapAction(req); soapAction != "" {
+		key += soapAction
+	}
+	return stringutil.Sha1hashString(key)
 }
 
 func updateConfigFile(exchange HttpExchange, options impostermodel2.ConfigGenerationOptions, resources []impostermodel2.Resource, configFile string) error {

--- a/internal/proxy/recorder.go
+++ b/internal/proxy/recorder.go
@@ -266,4 +266,3 @@ func updateConfigFile(exchange HttpExchange, options impostermodel2.ConfigGenera
 	logger.Debugf("wrote config file %s for %s %v", configFile, req.Method, req.URL)
 	return nil
 }
-

--- a/internal/proxy/recorder.go
+++ b/internal/proxy/recorder.go
@@ -37,7 +37,6 @@ type RecorderOptions struct {
 	IgnoreDuplicateRequests   bool
 	RecordOnlyResponseHeaders []string
 	FlatResponseFileStructure bool
-	Soap11Mode                bool
 }
 
 func StartRecorder(upstream string, dir string, options RecorderOptions) (chan HttpExchange, error) {
@@ -62,13 +61,9 @@ func StartRecorder(upstream string, dir string, options RecorderOptions) (chan H
 			exchange := <-recordC
 
 			var responseFilePrefix string
-			var requestHash string
-			if options.Soap11Mode {
-				// In SOAP mode, use SOAPAction + path for uniqueness
-				soapAction := extractSoapAction(exchange.Request)
-				requestHash = getRequestHash(exchange.Request) + "_" + soapAction
-			} else {
-				requestHash = getRequestHash(exchange.Request)
+			requestHash := getRequestHash(exchange.Request)
+			if soapAction := extractSoapAction(exchange.Request); soapAction != "" {
+				requestHash = requestHash + "_" + soapAction
 			}
 			if stringutil.Contains(requestHashes, requestHash) {
 				if options.IgnoreDuplicateRequests {
@@ -213,21 +208,14 @@ func buildResource(
 			}
 		}
 		resource.RequestHeaders = &headers
-	} else if options.Soap11Mode {
-		// In SOAP mode, capture the header that contains the action for matching
-		if soapAction := extractSoapAction(&req); soapAction != "" {
-			headers := make(map[string]string)
-			if req.Header.Get("SOAPAction") != "" {
-				// SOAP 1.1 style - use SOAPAction header
-				headers["SOAPAction"] = soapAction
-			} else {
-				// SOAP 1.2 style - use Content-Type header verbatim
-				if contentType := req.Header.Get("Content-Type"); contentType != "" {
-					headers["Content-Type"] = contentType
-				}
-			}
-			resource.RequestHeaders = &headers
+	} else if soapAction := extractSoapAction(&req); soapAction != "" {
+		headers := make(map[string]string)
+		if req.Header.Get("SOAPAction") != "" {
+			headers["SOAPAction"] = soapAction
+		} else if contentType := req.Header.Get("Content-Type"); contentType != "" {
+			headers["Content-Type"] = contentType
 		}
+		resource.RequestHeaders = &headers
 	}
 	if options.CaptureRequestBody && exchange.RequestBody != nil {
 		contentType := req.Header.Get("Content-Type")


### PR DESCRIPTION
## Summary
- Auto-detects SOAP actions from SOAPAction header (1.1) or Content-Type action parameter (1.2) — no flag required
- Uses the SOAP action in request hashing and response filenames so multiple SOAP operations on the same endpoint no longer collide
- Adds `application/soap+xml` to the text media type list for request capture eligibility

Based on the contribution in #82, with review feedback applied as individual commits.
