### PR TITLE
feat: add documentation header to generated Imposter config files

### DIFF
--- a/internal/impostermodel/configfile.go
+++ b/internal/impostermodel/configfile.go
@@ -17,9 +17,11 @@ limitations under the License.
 package impostermodel
 
 import (
+	"fmt"
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/imposter-project/imposter-cli/internal/fileutil"
 	"github.com/imposter-project/imposter-cli/internal/logging"
@@ -98,7 +100,42 @@ func GenerateConfig(options ConfigGenerationOptions, resources []Resource) []byt
 	if err != nil {
 		logger.Fatalf("unable to marshal imposter config: %v", err)
 	}
-	return config
+	return append([]byte(buildConfigHeader(options.PluginName)), config...)
+}
+
+// buildConfigHeader returns a YAML comment block describing the file and
+// linking to the relevant docs.imposter.sh pages for the given plugin.
+func buildConfigHeader(pluginName string) string {
+	links := []string{
+		"General configuration: https://docs.imposter.sh/configuration/",
+	}
+	switch pluginName {
+	case "rest":
+		links = append(links,
+			"REST plugin: https://docs.imposter.sh/rest_plugin/",
+			"Request matching: https://docs.imposter.sh/request_matching/",
+		)
+	case "openapi":
+		links = append(links,
+			"OpenAPI plugin: https://docs.imposter.sh/openapi_plugin/",
+		)
+	case "soap":
+		links = append(links,
+			"SOAP plugin: https://docs.imposter.sh/soap_plugin/",
+		)
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "# Imposter mock configuration (%s plugin)\n", pluginName)
+	b.WriteString("#\n")
+	b.WriteString("# Reference docs:\n")
+	for _, l := range links {
+		fmt.Fprintf(&b, "#   - %s\n", l)
+	}
+	b.WriteString("#\n")
+	b.WriteString("# Edit this file to customise your mock, then run: imposter up\n")
+	b.WriteString("\n")
+	return b.String()
 }
 
 func writeMockConfigAdjacent(anchorFilePath string, resources []Resource, forceOverwrite bool, options ConfigGenerationOptions) {

--- a/internal/impostermodel/configfile_test.go
+++ b/internal/impostermodel/configfile_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright © 2026 Pete Cornish <outofcoffee@gmail.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package impostermodel
+
+import (
+	"strings"
+	"testing"
+
+	"sigs.k8s.io/yaml"
+)
+
+func TestGenerateConfig_includesHeaderAndDocsLinks(t *testing.T) {
+	tests := []struct {
+		plugin       string
+		expectedLink string
+	}{
+		{plugin: "rest", expectedLink: "https://docs.imposter.sh/rest_plugin/"},
+		{plugin: "openapi", expectedLink: "https://docs.imposter.sh/openapi_plugin/"},
+		{plugin: "soap", expectedLink: "https://docs.imposter.sh/soap_plugin/"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.plugin, func(t *testing.T) {
+			out := GenerateConfig(ConfigGenerationOptions{PluginName: tt.plugin}, nil)
+			s := string(out)
+
+			if !strings.HasPrefix(s, "# Imposter mock configuration") {
+				t.Fatalf("expected header comment at start of file, got:\n%s", s)
+			}
+			if !strings.Contains(s, "https://docs.imposter.sh/configuration/") {
+				t.Errorf("expected general configuration docs link in header")
+			}
+			if !strings.Contains(s, tt.expectedLink) {
+				t.Errorf("expected plugin docs link %s in header", tt.expectedLink)
+			}
+
+			// The body must still be valid YAML containing the plugin field.
+			var parsed PluginConfig
+			if err := yaml.Unmarshal(out, &parsed); err != nil {
+				t.Fatalf("generated config is not valid YAML: %v", err)
+			}
+			if parsed.Plugin != tt.plugin {
+				t.Errorf("expected plugin %q in unmarshalled config, got %q", tt.plugin, parsed.Plugin)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Enhanced the generated Imposter mock configuration files by prepending a YAML comment header that includes helpful documentation links and usage instructions.

## Key Changes
- Modified `GenerateConfig()` to prepend a documentation header to generated configuration files
- Added `buildConfigHeader()` function that generates a YAML comment block containing:
  - A descriptive title indicating the plugin type
  - Links to general configuration documentation
  - Plugin-specific documentation links (REST, OpenAPI, or SOAP)
  - Instructions for customizing and running the mock
- Added comprehensive test coverage (`TestGenerateConfig_includesHeaderAndDocsLinks`) that validates:
  - Header comment is present at the start of generated files
  - Correct documentation links are included for each plugin type
  - Generated configuration remains valid YAML after header prepending

## Implementation Details
- The header is built as a string of YAML comments (lines prefixed with `#`)
- Plugin-specific documentation links are conditionally included based on the plugin name
- The REST plugin includes an additional link to request matching documentation
- The generated header is prepended to the YAML output without affecting YAML validity
