### PR TITLE
feat(docker): use env vars for configDir and port on Imposter 5.x+

### DIFF
--- a/internal/engine/docker/engine.go
+++ b/internal/engine/docker/engine.go
@@ -19,6 +19,15 @@ package docker
 import (
 	"context"
 	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/coreos/go-semver/semver"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/stdcopy"
@@ -30,13 +39,6 @@ import (
 	"github.com/imposter-project/imposter-cli/internal/stringutil"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
-	"io"
-	"os"
-	"path/filepath"
-	"strconv"
-	"strings"
-	"sync"
-	"time"
 )
 
 const containerConfigDir = "/opt/imposter/config"
@@ -74,13 +76,11 @@ func (d *DockerMockEngine) startWithOptions(wg *sync.WaitGroup, options engine.S
 	logger.Tracef("container user: %s", containerUser)
 
 	exposedPorts, portBindings := buildPorts(options)
+	useEnvConfig := usesEnvConfig(options.Version)
 	resp, err := cli.ContainerCreate(ctx, &container.Config{
-		Image: d.provider.imageAndTag,
-		Cmd: []string{
-			"--configDir=" + containerConfigDir,
-			fmt.Sprintf("--listenPort=%d", options.Port),
-		},
-		Env:          buildEnv(options),
+		Image:        d.provider.imageAndTag,
+		Cmd:          buildCmd(options, useEnvConfig),
+		Env:          buildEnv(options, useEnvConfig),
 		ExposedPorts: exposedPorts,
 		Labels:       containerLabels,
 		User:         containerUser,
@@ -136,13 +136,40 @@ func buildPorts(options engine.StartOptions) (nat.PortSet, nat.PortMap) {
 	return exposedPorts, portBindings
 }
 
-func buildEnv(options engine.StartOptions) []string {
+func buildEnv(options engine.StartOptions, useEnvConfig bool) []string {
 	env := engine.BuildEnv(options, engine.EnvOptions{IncludeHome: false, IncludePath: false})
+	if useEnvConfig {
+		env = append(env,
+			"IMPOSTER_CONFIG_DIR="+containerConfigDir,
+			fmt.Sprintf("IMPOSTER_PORT=%d", options.Port),
+		)
+	}
 	if options.EnableFileCache {
 		env = append(env, "IMPOSTER_CACHE_DIR=/tmp/imposter-cache", "IMPOSTER_OPENAPI_REMOTE_FILE_CACHE=true")
 	}
 	logger.Tracef("engine environment: %v", env)
 	return env
+}
+
+func buildCmd(options engine.StartOptions, useEnvConfig bool) []string {
+	if useEnvConfig {
+		return nil
+	}
+	return []string{
+		"--configDir=" + containerConfigDir,
+		fmt.Sprintf("--listenPort=%d", options.Port),
+	}
+}
+
+// 5.x dropped the --configDir and --listenPort CLI flags in favour of
+// IMPOSTER_CONFIG_DIR and IMPOSTER_PORT env vars. Unparseable versions
+// (e.g. "dev") use the new form.
+func usesEnvConfig(version string) bool {
+	v, err := semver.NewVersion(version)
+	if err != nil {
+		return true
+	}
+	return v.Major >= 5
 }
 
 func buildBinds(d *DockerMockEngine, options engine.StartOptions) []string {

--- a/internal/engine/docker/engine.go
+++ b/internal/engine/docker/engine.go
@@ -27,7 +27,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/coreos/go-semver/semver"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/stdcopy"
@@ -76,7 +75,7 @@ func (d *DockerMockEngine) startWithOptions(wg *sync.WaitGroup, options engine.S
 	logger.Tracef("container user: %s", containerUser)
 
 	exposedPorts, portBindings := buildPorts(options)
-	useEnvConfig := usesEnvConfig(options.Version)
+	useEnvConfig := engine.UsesEnvConfig(options.Version)
 	resp, err := cli.ContainerCreate(ctx, &container.Config{
 		Image:        d.provider.imageAndTag,
 		Cmd:          buildCmd(options, useEnvConfig),
@@ -159,17 +158,6 @@ func buildCmd(options engine.StartOptions, useEnvConfig bool) []string {
 		"--configDir=" + containerConfigDir,
 		fmt.Sprintf("--listenPort=%d", options.Port),
 	}
-}
-
-// 5.x dropped the --configDir and --listenPort CLI flags in favour of
-// IMPOSTER_CONFIG_DIR and IMPOSTER_PORT env vars. Unparseable versions
-// (e.g. "dev") use the new form.
-func usesEnvConfig(version string) bool {
-	v, err := semver.NewVersion(version)
-	if err != nil {
-		return true
-	}
-	return v.Major >= 5
 }
 
 func buildBinds(d *DockerMockEngine, options engine.StartOptions) []string {

--- a/internal/engine/docker/engine_unit_test.go
+++ b/internal/engine/docker/engine_unit_test.go
@@ -24,31 +24,6 @@ import (
 	"github.com/imposter-project/imposter-cli/internal/stringutil"
 )
 
-func TestUsesEnvConfig(t *testing.T) {
-	tests := []struct {
-		name    string
-		version string
-		want    bool
-	}{
-		{name: "3.x uses CLI flags", version: "3.40.0", want: false},
-		{name: "4.x uses CLI flags", version: "4.9.1", want: false},
-		{name: "4.x latest patch uses CLI flags", version: "4.99.99", want: false},
-		{name: "5.0.0 uses env vars", version: "5.0.0", want: true},
-		{name: "5.x uses env vars", version: "5.2.3", want: true},
-		{name: "6.x uses env vars", version: "6.0.0", want: true},
-		{name: "5.x pre-release uses env vars", version: "5.0.0-beta.1", want: true},
-		{name: "unparseable falls back to env vars", version: "dev", want: true},
-		{name: "empty version falls back to env vars", version: "", want: true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := usesEnvConfig(tt.version); got != tt.want {
-				t.Errorf("usesEnvConfig(%q) = %v, want %v", tt.version, got, tt.want)
-			}
-		})
-	}
-}
-
 func TestBuildCmd(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/internal/engine/docker/engine_unit_test.go
+++ b/internal/engine/docker/engine_unit_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright © 2021 Pete Cornish <outofcoffee@gmail.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package docker
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/imposter-project/imposter-cli/internal/engine"
+	"github.com/imposter-project/imposter-cli/internal/stringutil"
+)
+
+func TestUsesEnvConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    bool
+	}{
+		{name: "3.x uses CLI flags", version: "3.40.0", want: false},
+		{name: "4.x uses CLI flags", version: "4.9.1", want: false},
+		{name: "4.x latest patch uses CLI flags", version: "4.99.99", want: false},
+		{name: "5.0.0 uses env vars", version: "5.0.0", want: true},
+		{name: "5.x uses env vars", version: "5.2.3", want: true},
+		{name: "6.x uses env vars", version: "6.0.0", want: true},
+		{name: "5.x pre-release uses env vars", version: "5.0.0-beta.1", want: true},
+		{name: "unparseable falls back to env vars", version: "dev", want: true},
+		{name: "empty version falls back to env vars", version: "", want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := usesEnvConfig(tt.version); got != tt.want {
+				t.Errorf("usesEnvConfig(%q) = %v, want %v", tt.version, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildCmd(t *testing.T) {
+	tests := []struct {
+		name         string
+		options      engine.StartOptions
+		useEnvConfig bool
+		want         []string
+	}{
+		{
+			name:         "legacy 4.x emits configDir and listenPort flags",
+			options:      engine.StartOptions{Port: 8080},
+			useEnvConfig: false,
+			want: []string{
+				"--configDir=/opt/imposter/config",
+				"--listenPort=8080",
+			},
+		},
+		{
+			name:         "5.x+ omits CLI flags",
+			options:      engine.StartOptions{Port: 8080},
+			useEnvConfig: true,
+			want:         nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildCmd(tt.options, tt.useEnvConfig)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("buildCmd() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildEnv(t *testing.T) {
+	t.Run("legacy 4.x omits IMPOSTER_CONFIG_DIR and IMPOSTER_PORT", func(t *testing.T) {
+		env := buildEnv(engine.StartOptions{Port: 8080, LogLevel: "DEBUG"}, false)
+		if stringutil.ContainsPrefix(env, "IMPOSTER_CONFIG_DIR=") {
+			t.Errorf("expected no IMPOSTER_CONFIG_DIR, got env: %v", env)
+		}
+		if stringutil.ContainsPrefix(env, "IMPOSTER_PORT=") {
+			t.Errorf("expected no IMPOSTER_PORT, got env: %v", env)
+		}
+	})
+
+	t.Run("5.x+ includes IMPOSTER_CONFIG_DIR and IMPOSTER_PORT", func(t *testing.T) {
+		env := buildEnv(engine.StartOptions{Port: 9090, LogLevel: "DEBUG"}, true)
+		if !stringutil.Contains(env, "IMPOSTER_CONFIG_DIR=/opt/imposter/config") {
+			t.Errorf("expected IMPOSTER_CONFIG_DIR=/opt/imposter/config, got env: %v", env)
+		}
+		if !stringutil.Contains(env, "IMPOSTER_PORT=9090") {
+			t.Errorf("expected IMPOSTER_PORT=9090, got env: %v", env)
+		}
+	})
+
+	t.Run("file cache adds cache env vars regardless of version", func(t *testing.T) {
+		env := buildEnv(engine.StartOptions{Port: 8080, LogLevel: "DEBUG", EnableFileCache: true}, true)
+		if !stringutil.Contains(env, "IMPOSTER_CACHE_DIR=/tmp/imposter-cache") {
+			t.Errorf("expected IMPOSTER_CACHE_DIR=/tmp/imposter-cache, got env: %v", env)
+		}
+		if !stringutil.Contains(env, "IMPOSTER_OPENAPI_REMOTE_FILE_CACHE=true") {
+			t.Errorf("expected IMPOSTER_OPENAPI_REMOTE_FILE_CACHE=true, got env: %v", env)
+		}
+	})
+}

--- a/internal/engine/version.go
+++ b/internal/engine/version.go
@@ -36,6 +36,19 @@ func ResolveLatestToVersion(engineType EngineType, allowCached bool) (string, er
 	return latest, nil
 }
 
+// UsesEnvConfig reports whether the given engine version expects its config
+// directory and listen port via IMPOSTER_CONFIG_DIR and IMPOSTER_PORT env
+// vars (5.x and later) rather than --configDir and --listenPort CLI flags
+// (4.x and earlier). Unparseable versions (e.g. "dev") default to the env-var
+// form.
+func UsesEnvConfig(version string) bool {
+	v, err := semver.NewVersion(version)
+	if err != nil {
+		return true
+	}
+	return v.Major >= 5
+}
+
 func GetHighestVersion(engines []EngineMetadata) string {
 	var highest *semver.Version
 	for _, engine := range engines {

--- a/internal/engine/version_test.go
+++ b/internal/engine/version_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright © 2021 Pete Cornish <outofcoffee@gmail.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import "testing"
+
+func TestUsesEnvConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    bool
+	}{
+		{name: "3.x uses CLI flags", version: "3.40.0", want: false},
+		{name: "4.x uses CLI flags", version: "4.9.1", want: false},
+		{name: "4.x latest patch uses CLI flags", version: "4.99.99", want: false},
+		{name: "5.0.0 uses env vars", version: "5.0.0", want: true},
+		{name: "5.x uses env vars", version: "5.2.3", want: true},
+		{name: "6.x uses env vars", version: "6.0.0", want: true},
+		{name: "5.x pre-release uses env vars", version: "5.0.0-beta.1", want: true},
+		{name: "unparseable falls back to env vars", version: "dev", want: true},
+		{name: "empty version falls back to env vars", version: "", want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := UsesEnvConfig(tt.version); got != tt.want {
+				t.Errorf("UsesEnvConfig(%q) = %v, want %v", tt.version, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Switch the Docker engine to set configDir and port via environment variables when running Imposter 5.x or later.

## Summary
- Detect the engine version with semver and pick the right wiring: `--configDir` / `--listenPort` CLI flags for 4.x and earlier, `IMPOSTER_CONFIG_DIR` / `IMPOSTER_PORT` env vars for 5.x+.
- Unparseable versions (e.g. `dev`) default to the env-var form so ongoing development tracks the new interface.

## Implementation details
Imposter 5.x removed the `--configDir` and `--listenPort` CLI flags, so passing them as `Cmd` args breaks startup against newer images. The version check uses the existing `coreos/go-semver` dependency. When the env-var path is taken, `Cmd` is left empty and the container falls back to the image's default entrypoint args.