### PR TITLE
feat: add --id-file flag to up and down commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ Each command has full help via `imposter <command> --help`.
 
 | Command | What it does |
 | --- | --- |
-| `imposter up [DIR]` | Start a live mock from Imposter config in `DIR` (defaults to current directory). Add `-s` to scaffold first, or `-d` to background it. |
+| `imposter up [DIR]` | Start a live mock from Imposter config in `DIR` (defaults to current directory). Add `-s` to scaffold first, or `-d` to background it (use `--id-file` to record its ID). |
 | `imposter scaffold [DIR]` | Generate Imposter config from any OpenAPI/Swagger or WSDL files in `DIR`. |
 | `imposter proxy URL` | Forward traffic to `URL` and record each exchange to disk as a replayable mock. Add `--insecure` to skip TLS verification. |
-| `imposter down ID` | Stop the mock with the given ID (see `imposter ls`). `-a` / `--all` stops every managed mock across all engine types. |
+| `imposter down ID` | Stop the mock with the given ID (see `imposter ls`), or read the ID from a file with `--id-file`. `-a` / `--all` stops every managed mock across all engine types. |
 | `imposter list` | List running mocks and their health across all engine types. `-t` filters by engine type; `-qx` makes a tidy healthcheck. |
 | `imposter bundle [DIR]` | Bundle config and engine into a Docker image or Lambda zip. |
 | `imposter doctor` | Check that you have at least one engine ready to run. |

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -27,7 +27,8 @@ import (
 )
 
 var downFlags = struct {
-	all bool
+	all    bool
+	idFile string
 }{}
 
 // downCmd represents the down command
@@ -37,26 +38,59 @@ var downCmd = &cobra.Command{
 	Long: `Stops a single running Imposter mock identified by ID, or all
 managed mocks across every engine type with --all.
 
+The ID can be given as an argument or read from a file with --id-file
+(as written by 'imposter up --id-file').
+
 Use 'imposter ls' to discover the IDs of running mocks.`,
 	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		if downFlags.all {
-			if len(args) > 0 {
-				logger.Fatal("cannot specify both --all and a mock ID")
+			if len(args) > 0 || downFlags.idFile != "" {
+				logger.Fatal("cannot specify --all together with a mock ID or --id-file")
 			}
 			stopAllEngines()
 			return
 		}
-		if len(args) == 0 {
-			logger.Fatal("a mock ID is required (or use --all to stop all mocks); see 'imposter ls' for IDs")
+
+		var id string
+		if downFlags.idFile != "" {
+			if len(args) > 0 {
+				logger.Fatal("cannot specify both a mock ID and --id-file")
+			}
+			var err error
+			id, err = readMockIDFile(downFlags.idFile)
+			if err != nil {
+				logger.Fatal(err)
+			}
+		} else {
+			if len(args) == 0 {
+				logger.Fatal("a mock ID is required (or use --all to stop all mocks, or --id-file to read one from a file); see 'imposter ls' for IDs")
+			}
+			id = args[0]
 		}
-		stopMockByID(args[0])
+		stopMockByID(id)
 	},
 }
 
 func init() {
 	downCmd.Flags().BoolVarP(&downFlags.all, "all", "a", false, "Stop all managed mocks across all engine types")
+	downCmd.Flags().StringVar(&downFlags.idFile, "id-file", "", "Read the mock ID to stop from this file (as written by 'imposter up --id-file')")
 	rootCmd.AddCommand(downCmd)
+}
+
+// readMockIDFile reads a mock ID written by 'imposter up --id-file',
+// trimming surrounding whitespace. Returns an error if the file cannot be
+// read or contains no ID.
+func readMockIDFile(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	id := strings.TrimSpace(string(data))
+	if id == "" {
+		return "", fmt.Errorf("id file %s contains no mock ID", path)
+	}
+	return id, nil
 }
 
 func stopAllEngines() {

--- a/cmd/down_test.go
+++ b/cmd/down_test.go
@@ -17,9 +17,13 @@ limitations under the License.
 package cmd
 
 import (
-	"github.com/imposter-project/imposter-cli/internal/engine"
-	"github.com/stretchr/testify/require"
+	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/imposter-project/imposter-cli/internal/engine"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_stopEngine(t *testing.T) {
@@ -59,11 +63,73 @@ func Test_downCmd_requires_id_or_all(t *testing.T) {
 }
 
 func Test_downCmd_rejects_id_with_all(t *testing.T) {
+	resetDownFlags()
 	rootCmd.SetArgs([]string{"down", "--all", "abc123"})
 	err := runWithRecovery(func() {
 		_ = rootCmd.Execute()
 	})
 	require.Error(t, err, "should reject ID together with --all")
+}
+
+func Test_downCmd_rejects_id_file_with_all(t *testing.T) {
+	resetDownFlags()
+	idFile := writeTempIDFile(t, "abc123")
+	rootCmd.SetArgs([]string{"down", "--all", "--id-file", idFile})
+	err := runWithRecovery(func() {
+		_ = rootCmd.Execute()
+	})
+	require.Error(t, err, "should reject --id-file together with --all")
+}
+
+func Test_downCmd_rejects_id_file_with_id_arg(t *testing.T) {
+	resetDownFlags()
+	idFile := writeTempIDFile(t, "abc123")
+	rootCmd.SetArgs([]string{"down", "abc123", "--id-file", idFile})
+	err := runWithRecovery(func() {
+		_ = rootCmd.Execute()
+	})
+	require.Error(t, err, "should reject a mock ID together with --id-file")
+}
+
+func Test_downCmd_id_file_missing_is_fatal(t *testing.T) {
+	resetDownFlags()
+	rootCmd.SetArgs([]string{"down", "--id-file", filepath.Join(t.TempDir(), "absent.id")})
+	err := runWithRecovery(func() {
+		_ = rootCmd.Execute()
+	})
+	require.Error(t, err, "should fail when the id file cannot be read")
+}
+
+func Test_readMockIDFile(t *testing.T) {
+	t.Run("reads and trims surrounding whitespace", func(t *testing.T) {
+		path := writeTempIDFile(t, "  abc123\n")
+		id, err := readMockIDFile(path)
+		require.NoError(t, err)
+		assert.Equal(t, "abc123", id)
+	})
+
+	t.Run("errors when the file is missing", func(t *testing.T) {
+		_, err := readMockIDFile(filepath.Join(t.TempDir(), "absent.id"))
+		assert.Error(t, err)
+	})
+
+	t.Run("errors when the file holds no ID", func(t *testing.T) {
+		path := writeTempIDFile(t, "   \n\t")
+		_, err := readMockIDFile(path)
+		assert.Error(t, err)
+	})
+}
+
+func resetDownFlags() {
+	downFlags.all = false
+	downFlags.idFile = ""
+}
+
+func writeTempIDFile(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "mock.id")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+	return path
 }
 
 func Test_stopMockByID_unknown(t *testing.T) {

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -51,6 +51,7 @@ var upFlags = struct {
 	debugMode           bool
 	detach              string
 	logFile             string
+	idFile              string
 }{}
 
 // upCmd represents the up command
@@ -114,7 +115,7 @@ If CONFIG_DIR is not specified, the current working directory is used.`,
 			DirMounts:       upFlags.dirMounts,
 			DebugMode:       upFlags.debugMode,
 		}
-		restartOnChange := applyDetachOptions(&startOptions, engineType, upFlags.detach, upFlags.logFile, upFlags.restartOnChange)
+		restartOnChange := applyDetachOptions(&startOptions, engineType, upFlags.detach, upFlags.logFile, upFlags.idFile, upFlags.restartOnChange)
 
 		start(&lib, startOptions, configDir, restartOnChange)
 	},
@@ -124,9 +125,12 @@ If CONFIG_DIR is not specified, the current working directory is used.`,
 // and returns the (possibly disabled) auto-restart setting. Auto-restart
 // is incompatible with detaching because the config-dir watcher lives in
 // the foreground CLI process, which exits once the mock is backgrounded.
-func applyDetachOptions(startOptions *engine.StartOptions, engineType engine.EngineType, detach string, logFile string, restartOnChange bool) bool {
+func applyDetachOptions(startOptions *engine.StartOptions, engineType engine.EngineType, detach string, logFile string, idFile string, restartOnChange bool) bool {
 	switch detach {
 	case "":
+		if idFile != "" {
+			logger.Warn("--id-file is ignored without --detach")
+		}
 		return restartOnChange
 	case "healthy":
 		startOptions.Detach = engine.DetachHealthy
@@ -135,6 +139,8 @@ func applyDetachOptions(startOptions *engine.StartOptions, engineType engine.Eng
 	default:
 		logger.Fatalf("invalid --detach mode %q (valid: healthy, now)", detach)
 	}
+
+	startOptions.DetachIdFile = idFile
 
 	if restartOnChange {
 		logger.Warn("--auto-restart is not supported with --detach; auto-restart disabled")
@@ -175,6 +181,7 @@ func init() {
 	upCmd.Flags().StringVarP(&upFlags.detach, "detach", "d", "", "Run the mock in the background and return control to the terminal. Optional mode: 'healthy' (default, wait for the healthcheck before detaching) or 'now' (detach immediately)")
 	upCmd.Flags().Lookup("detach").NoOptDefVal = "healthy"
 	upCmd.Flags().StringVar(&upFlags.logFile, "log-file", "", "(Process engine types only) File to write detached mock logs to (default ~/.imposter/logs/imposter-<port>.log)")
+	upCmd.Flags().StringVar(&upFlags.idFile, "id-file", "", "(Detach mode only) File to write the started mock ID to (plaintext, no newline)")
 	registerEngineTypeCompletions(upCmd)
 	rootCmd.AddCommand(upCmd)
 }
@@ -270,11 +277,23 @@ func start(lib *engine.EngineLibrary, startOptions engine.StartOptions, configDi
 }
 
 func printDetachSummary(mockEngine engine.MockEngine, startOptions engine.StartOptions) {
-	logger.Infof("mock running in the background (id: %s, port: %d)", mockEngine.GetID(), startOptions.Port)
+	id := mockEngine.GetID()
+	if startOptions.DetachIdFile != "" {
+		if err := writeMockIDFile(startOptions.DetachIdFile, id); err != nil {
+			logger.Warnf("failed to write mock ID to %s: %s", startOptions.DetachIdFile, err)
+		}
+	}
+	logger.Infof("mock running in the background (id: %s, port: %d)", id, startOptions.Port)
 	if startOptions.DetachLog != "" {
 		logger.Infof("logs: %s", startOptions.DetachLog)
 	}
 	logger.Info("use 'imposter ls' to list running mocks, or 'imposter down' to stop them")
+}
+
+// writeMockIDFile writes the mock ID to path as plaintext with no trailing
+// newline, so the file can be consumed directly by scripts.
+func writeMockIDFile(path string, id string) error {
+	return os.WriteFile(path, []byte(id), 0644)
 }
 
 // listen for an interrupt from the OS, then attempt engine cleanup.

--- a/cmd/up_test.go
+++ b/cmd/up_test.go
@@ -17,13 +17,29 @@ limitations under the License.
 package cmd
 
 import (
+	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/imposter-project/imposter-cli/internal/config"
 	"github.com/imposter-project/imposter-cli/internal/engine"
 	"github.com/stretchr/testify/assert"
 )
+
+// fakeMockEngine is a minimal engine.MockEngine used to exercise the
+// detach summary path; only GetID returns a meaningful value.
+type fakeMockEngine struct{ id string }
+
+func (f fakeMockEngine) Start(*sync.WaitGroup) bool                    { return true }
+func (f fakeMockEngine) Stop(*sync.WaitGroup)                          {}
+func (f fakeMockEngine) StopImmediately(*sync.WaitGroup)               {}
+func (f fakeMockEngine) Restart(*sync.WaitGroup)                       {}
+func (f fakeMockEngine) ListAllManaged() ([]engine.ManagedMock, error) { return nil, nil }
+func (f fakeMockEngine) StopAllManaged() int                           { return 0 }
+func (f fakeMockEngine) StopManaged(string) (bool, error)              { return false, nil }
+func (f fakeMockEngine) GetVersionString() (string, error)             { return "", nil }
+func (f fakeMockEngine) GetID() string                                 { return f.id }
 
 func Test_applyDetachOptions(t *testing.T) {
 	tmpHome := t.TempDir()
@@ -32,7 +48,7 @@ func Test_applyDetachOptions(t *testing.T) {
 
 	t.Run("no detach leaves foreground mode and keeps auto-restart", func(t *testing.T) {
 		opts := engine.StartOptions{Port: 8080}
-		restart := applyDetachOptions(&opts, engine.EngineTypeJvmSingleJar, "", "", true)
+		restart := applyDetachOptions(&opts, engine.EngineTypeJvmSingleJar, "", "", "", true)
 		assert.Equal(t, engine.DetachNone, opts.Detach)
 		assert.False(t, opts.IsDetached())
 		assert.True(t, restart)
@@ -41,35 +57,102 @@ func Test_applyDetachOptions(t *testing.T) {
 
 	t.Run("detach=healthy waits for the healthcheck", func(t *testing.T) {
 		opts := engine.StartOptions{Port: 8080}
-		restart := applyDetachOptions(&opts, engine.EngineTypeJvmSingleJar, "healthy", "", true)
+		restart := applyDetachOptions(&opts, engine.EngineTypeJvmSingleJar, "healthy", "", "", true)
 		assert.Equal(t, engine.DetachHealthy, opts.Detach)
 		assert.False(t, restart, "auto-restart must be disabled when detached")
 	})
 
 	t.Run("detach=now returns immediately", func(t *testing.T) {
 		opts := engine.StartOptions{Port: 8080}
-		applyDetachOptions(&opts, engine.EngineTypeNative, "now", "", false)
+		applyDetachOptions(&opts, engine.EngineTypeNative, "now", "", "", false)
 		assert.Equal(t, engine.DetachNow, opts.Detach)
 	})
 
 	t.Run("process engine resolves default log path", func(t *testing.T) {
 		opts := engine.StartOptions{Port: 1234}
-		applyDetachOptions(&opts, engine.EngineTypeJvmSingleJar, "healthy", "", false)
+		applyDetachOptions(&opts, engine.EngineTypeJvmSingleJar, "healthy", "", "", false)
 		expected := filepath.Join(tmpHome, "logs", "imposter-1234.log")
 		assert.Equal(t, expected, opts.DetachLog)
 	})
 
 	t.Run("explicit log file is honoured and made absolute", func(t *testing.T) {
 		opts := engine.StartOptions{Port: 8080}
-		applyDetachOptions(&opts, engine.EngineTypeNative, "healthy", "relative/mock.log", false)
+		applyDetachOptions(&opts, engine.EngineTypeNative, "healthy", "relative/mock.log", "", false)
 		assert.True(t, filepath.IsAbs(opts.DetachLog))
 		assert.Equal(t, "mock.log", filepath.Base(opts.DetachLog))
 	})
 
 	t.Run("docker engine does not set a detach log", func(t *testing.T) {
 		opts := engine.StartOptions{Port: 8080}
-		applyDetachOptions(&opts, engine.EngineTypeDockerCore, "healthy", "", false)
+		applyDetachOptions(&opts, engine.EngineTypeDockerCore, "healthy", "", "", false)
 		assert.Equal(t, engine.DetachHealthy, opts.Detach)
 		assert.Empty(t, opts.DetachLog)
+	})
+
+	t.Run("id file is stored when detached", func(t *testing.T) {
+		opts := engine.StartOptions{Port: 8080}
+		applyDetachOptions(&opts, engine.EngineTypeDockerCore, "healthy", "", "mock.id", false)
+		assert.Equal(t, "mock.id", opts.DetachIdFile)
+	})
+
+	t.Run("id file is ignored without detach", func(t *testing.T) {
+		opts := engine.StartOptions{Port: 8080}
+		applyDetachOptions(&opts, engine.EngineTypeJvmSingleJar, "", "", "mock.id", false)
+		assert.Empty(t, opts.DetachIdFile)
+	})
+}
+
+func Test_writeMockIDFile(t *testing.T) {
+	t.Run("writes plaintext id with no trailing newline", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "mock.id")
+		err := writeMockIDFile(path, "abc123")
+		assert.NoError(t, err)
+
+		content, err := os.ReadFile(path)
+		assert.NoError(t, err)
+		assert.Equal(t, "abc123", string(content), "mock ID must be written as plaintext with no trailing newline")
+	})
+
+	t.Run("overwrites an existing file rather than appending", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "mock.id")
+		assert.NoError(t, writeMockIDFile(path, "first"))
+		assert.NoError(t, writeMockIDFile(path, "second"))
+
+		content, err := os.ReadFile(path)
+		assert.NoError(t, err)
+		assert.Equal(t, "second", string(content), "re-running must replace the previous ID")
+	})
+
+	t.Run("returns an error when the path is not writable", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "missing-dir", "mock.id")
+		assert.Error(t, writeMockIDFile(path, "abc123"))
+	})
+}
+
+func Test_printDetachSummary(t *testing.T) {
+	t.Run("writes the engine ID to the id-file when set", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "mock.id")
+		printDetachSummary(fakeMockEngine{id: "engine-42"}, engine.StartOptions{Port: 8080, DetachIdFile: path})
+
+		content, err := os.ReadFile(path)
+		assert.NoError(t, err)
+		assert.Equal(t, "engine-42", string(content))
+	})
+
+	t.Run("writes no file when id-file is unset", func(t *testing.T) {
+		dir := t.TempDir()
+		printDetachSummary(fakeMockEngine{id: "engine-42"}, engine.StartOptions{Port: 8080})
+
+		entries, err := os.ReadDir(dir)
+		assert.NoError(t, err)
+		assert.Empty(t, entries, "no id-file should be created when the flag is unset")
+	})
+
+	t.Run("tolerates an unwritable id-file path", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "missing-dir", "mock.id")
+		assert.NotPanics(t, func() {
+			printDetachSummary(fakeMockEngine{id: "engine-42"}, engine.StartOptions{Port: 8080, DetachIdFile: path})
+		})
+		assert.NoFileExists(t, path)
 	})
 }

--- a/internal/engine/api.go
+++ b/internal/engine/api.go
@@ -54,6 +54,10 @@ type StartOptions struct {
 	// DetachLog is the resolved absolute path that a detached process
 	// engine writes stdout/stderr to. Unused by the docker engine.
 	DetachLog string
+	// DetachIdFile is the path the mock ID is written to (plaintext, no
+	// trailing newline) once a detached mock has started. Empty disables
+	// the behaviour.
+	DetachIdFile string
 }
 
 // IsDetached reports whether the mock should be run in the background.


### PR DESCRIPTION
Add a paired `--id-file` flag to `imposter up` and `imposter down` so a detached mock's ID can be captured to a file and used later to stop it.

## Summary
- `imposter up --id-file FILE`: in detach mode, write the started mock's ID to `FILE` as plaintext with no trailing newline. Warn and ignore the flag when used without `--detach`.
- `imposter down --id-file FILE`: read the mock ID to stop from `FILE` (whitespace trimmed) instead of passing it as an argument. Mutually exclusive with both a positional ID and `--all`.
- The ID is the engine's mock ID for all engines: the docker container ID, or the PID for the JVM and native engines.
- Carry the up-side path on `StartOptions.DetachIdFile`, mirroring the existing `DetachLog`.
- Document the flags in the README command table.
- Add unit tests for flag handling, the no-trailing-newline write contract, overwrite-on-rerun, the detach summary write path, ID-file reading (trim/missing/empty), and the down-command validation rules.

## Implementation details
- A failure to write the ID file on `up` is logged as a warning rather than treated as fatal: the mock has already started by that point and the ID is still printed to the console, so failing the command would be misleading.
- `down --id-file` does not delete the file after stopping the mock — a stop command removing user-provided input would be surprising and destructive.
