### PR TITLE
Add brew trust command to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ You'll need [Docker](https://docs.docker.com/get-docker/), or alternatively a JV
 
 ```shell
 brew tap imposter-project/imposter
+brew trust imposter-project/imposter
 brew install imposter
 ```
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -23,6 +23,7 @@ Use these instructions to get up and running quickly.
 If you have Homebrew installed:
 
     brew tap imposter-project/imposter
+    brew trust imposter-project/imposter
     brew install imposter
 
 ### Shell script


### PR DESCRIPTION
## Summary
Updated installation documentation to include the `brew trust` command when installing Imposter via Homebrew.

## Changes
- Added `brew trust imposter-project/imposter` command to README.md installation instructions
- Added `brew trust imposter-project/imposter` command to docs/install.md installation instructions

## Details
The `brew trust` command is now required as part of the Homebrew installation process for the imposter-project/imposter tap. This ensures users have the proper security configuration when installing from this third-party tap.